### PR TITLE
Custom Configuration File Support & Option Renaming

### DIFF
--- a/src/ConfigLoader/CompositeConfigLoader.php
+++ b/src/ConfigLoader/CompositeConfigLoader.php
@@ -55,7 +55,7 @@ final readonly class CompositeConfigLoader implements ConfigLoaderInterface
         }
 
         if (!$atLeastOneLoaded) {
-            throw new ConfigLoaderException('No configuration could be loaded with any available loader');
+            throw new ConfigLoaderException('There are no loaders that can load the configuration in the given path');
         }
 
         return $registry;

--- a/src/ConfigLoader/ConfigurationProvider.php
+++ b/src/ConfigLoader/ConfigurationProvider.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\ConfigLoader;
+
+use Butschster\ContextGenerator\ConfigLoader\Exception\ConfigLoaderException;
+use Butschster\ContextGenerator\FilesInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for providing configuration loaders based on different sources
+ */
+final readonly class ConfigurationProvider
+{
+    public function __construct(
+        private ConfigLoaderFactory $loaderFactory,
+        private FilesInterface $files,
+        private string $rootPath,
+        private ?LoggerInterface $logger = null,
+        private array $parserPlugins = [],
+    ) {}
+
+    /**
+     * Get a config loader from an inline JSON string
+     */
+    public function fromString(string $jsonConfig): ConfigLoaderInterface
+    {
+        $this->logger?->info('Using inline JSON configuration');
+
+        return $this->loaderFactory->createFromString(
+            jsonConfig: $jsonConfig,
+            parserPlugins: $this->parserPlugins,
+        );
+    }
+
+    /**
+     * Get a config loader for a specific path (file or directory)
+     */
+    public function fromPath(string $configPath): ConfigLoaderInterface
+    {
+        $resolvedPath = $this->resolvePath($configPath);
+
+        if (\is_dir($resolvedPath)) {
+            $this->logger?->info('Looking for configuration files in directory', [
+                'directory' => $resolvedPath,
+            ]);
+
+            return $this->loaderFactory->create(
+                rootPath: $resolvedPath,
+                parserPlugins: $this->parserPlugins,
+            );
+        }
+        $this->logger?->info('Loading configuration from specific file', [
+            'file' => $resolvedPath,
+        ]);
+
+        return $this->loaderFactory->createForFile(
+            filePath: $resolvedPath,
+            parserPlugins: $this->parserPlugins,
+        );
+
+    }
+
+    /**
+     * Get a config loader using the default paths
+     */
+    public function fromDefaultLocation(): ConfigLoaderInterface
+    {
+        $this->logger?->info('Loading configuration from default location', [
+            'rootPath' => $this->rootPath,
+        ]);
+
+        return $this->loaderFactory->create(
+            rootPath: $this->rootPath,
+            parserPlugins: $this->parserPlugins,
+        );
+    }
+
+    /**
+     * Resolve a path (absolute or relative to root path)
+     */
+    private function resolvePath(string $path): string
+    {
+        // If it's an absolute path, use it directly
+        if ($this->isAbsolutePath($path)) {
+            $resolvedPath = $path;
+        } else {
+            // Otherwise, resolve it relative to the root path
+            $resolvedPath = \rtrim($this->rootPath, '/') . '/' . $path;
+        }
+
+        // Check if the path exists
+        if (!$this->files->exists($resolvedPath)) {
+            throw new ConfigLoaderException(\sprintf('Path not found: %s', $resolvedPath));
+        }
+
+        return $resolvedPath;
+    }
+
+    /**
+     * Check if a path is absolute
+     */
+    private function isAbsolutePath(string $path): bool
+    {
+        return \str_starts_with($path, '/');
+    }
+}

--- a/src/ConfigLoader/Reader/StringJsonReader.php
+++ b/src/ConfigLoader/Reader/StringJsonReader.php
@@ -12,14 +12,7 @@ use Psr\Log\LoggerInterface;
  */
 final readonly class StringJsonReader implements ReaderInterface
 {
-    private string $jsonContent;
-
-    public function __construct(
-        string $jsonContent,
-        private ?LoggerInterface $logger = null,
-    ) {
-        $this->jsonContent = $jsonContent;
-    }
+    public function __construct(private string $jsonContent, private ?LoggerInterface $logger = null) {}
 
     public function read(string $path): array
     {


### PR DESCRIPTION
This PR adds support for specifying a custom configuration file path using the `-c` or `--config-file` option in the generate command. Users can now point to a specific configuration file instead of relying on the default naming conventions. 

It also renames the inline configuration option from `-c/--config` to `-i/--inline` for better clarity and consistency.

## Key changes:
- Enhanced path resolution to handle both absolute and relative paths
- Added support for both file and directory inputs (when a directory is specified, it looks for standard config files within it)
- Renamed `-c/--config` option to `-i/--inline` to better reflect its purpose
- Improved error reporting for invalid or missing configuration paths

## Usage examples:
- `ctx generate -c src/another_config.yaml` - Uses a specific config file
- `ctx generate -c src/` - Looks for standard config files in the specified directory
- `ctx generate` - Uses default behavior (looking for config files in the root path)
- `ctx generate -i '{"documents":[...]}` - Uses inline JSON