### PR TITLE
Enhanced Tree View Configuration

### DIFF
--- a/context.yaml
+++ b/context.yaml
@@ -1,14 +1,12 @@
 documents:
-
   - description: "Context Generator Project Structure"
     outputPath: "project-structure.md"
     sources:
       - type: tree
-        sourcePaths: [ "src" ]
-        maxDepth: 3
-        includeFiles: false
+        sourcePaths:
+          - src
         showCharCount: true
-        showSize: false
+        showSize: true
         dirContext:
           "src": "Root directory containing all Context Generator source code."
           "src/ConfigLoader": "Configuration loading system that reads, parses, and validates config files in JSON, PHP, and YAML formats."
@@ -41,413 +39,208 @@ documents:
           a high-level overview of the project organization and helps understand the 
           relationships between different components.
 
-  - description: "Context Generator Core Components"
-    outputPath: "core-components.md"
-    sources:
-      - type: text
-        content: >-
-          # Context Generator Core Components
-
-          The Context Generator consists of several key architectural components that work
-          together to provide its functionality. This document explains the relationships
-          between these components and their roles in the overall system.
-
-          ## High-Level Architecture
-
-          The Context Generator follows a pipeline architecture where:
-
-          1. **Configuration Loading**: Configurations are loaded from files
-          2. **Document Definition**: Documents are defined with their sources
-          3. **Source Content Fetching**: Content is retrieved from various sources
-          4. **Content Modification**: Fetched content is transformed as needed
-          5. **Document Compilation**: Processed content is compiled into output documents
-
-          ## Key Component Relationships
-
-          - **Sources & Fetchers**: Each source type (File, GitHub, URL, etc.) has a corresponding
-            fetcher that knows how to retrieve its content. The fetcher system is extensible through
-            the `SourceFetcherInterface` and `SourceFetcherRegistry`.
-
-          - **Documents & Sources**: Documents are containers that aggregate content from multiple
-            sources. The `Document` class manages the relationship to its sources.
-
-          - **Modifiers & Content**: Modifiers transform content after it's fetched from sources.
-            The `ModifiersApplier` coordinates applying a sequence of modifiers to content.
-
-          - **Configuration & Registry**: Configuration is parsed into registries that store
-            document and modifier definitions. The `DocumentRegistry` and `SourceModifierRegistry`
-            provide access to these definitions.
-
-          - **Compilation & Output**: The `DocumentCompiler` orchestrates the entire process,
-            from fetching content to applying modifiers to generating output files.
-
-      - type: tree
-        sourcePaths: [ "src" ]
-        maxDepth: 1
-        includeFiles: true
-        description: >-
-          Top-level view of the Context Generator source directory structure showing
-          the main components and their organization.
-
-  - description: "Core Source Interfaces and Base Classes"
-    outputPath: "core-sources.md"
+  - description: Core Interfaces
+    outputPath: core/interfaces.md
     sources:
       - type: file
-        sourcePaths: [ "src" ]
-        filePattern: [ "SourceInterface.php", "BaseSource.php", "SourceWithModifiers.php", "SourceModifierInterface.php", "SourceParserInterface.php" ]
-        description: >-
-          The fundamental interfaces and abstract classes that form the foundation of the Context Generator's source system.
-          SourceInterface defines the contract for all content sources, while BaseSource provides a common implementation.
-          SourceWithModifiers extends the base functionality with content transformation capabilities.
-          SourceModifierInterface and SourceParserInterface define contracts for modifying and parsing source content.
-          These components establish the core architecture for retrieving and processing content from various locations.
+        sourcePaths: src
+        filePattern:
+          - '*Interface.php'
+          - 'SourceInterface.php'
+          - 'SourceModifierInterface.php'
+          - 'FilesInterface.php'
+        showTreeView: true
 
-  - description: "Source Type Implementations"
-    outputPath: "source-implementations.md"
+  - description: Configuration System
+    outputPath: core/config-loader.md
     sources:
       - type: file
-        sourcePaths: [ "src/Source" ]
-        filePattern: [ "*.php" ]
-        notPath: [ "src/Source/*/", "*/Exception/*" ]
-        description: >-
-          Top-level source implementation classes that define the core source hierarchy.
-          These classes establish the base functionality for all source types and provide
-          abstract implementations that concrete sources extend. They define how sources
-          are structured, instantiated, and configured from JSON or PHP configurations.
+        sourcePaths: src/ConfigLoader
+        filePattern: '*.php'
+        showTreeView: true
 
-      - type: file
-        sourcePaths: [ "src/Source/File", "src/Source/Text", "src/Source/Url", "src/Source/Github", "src/Source/GitDiff", "src/Source/Composer", "src/Source/Tree" ]
-        filePattern: [ "*Source.php", "*Fetcher.php" ]
-        description: >-
-          Concrete source type implementations with their corresponding fetchers:
-          - FileSource: Retrieves content from local filesystem with pattern matching and filtering
-          - TextSource: Embeds custom text content directly into documents
-          - UrlSource: Fetches content from web pages with CSS selector support
-          - GithubSource: Pulls files from GitHub repositories with authentication
-          - GitDiffSource: Extracts changes from Git commits or working tree
-          - ComposerSource: Extracts information from Composer packages
-          - TreeSource: Generates directory structure visualizations
-          Each source type has a dedicated fetcher (e.g., FileSourceFetcher) responsible for
-          retrieving and processing content according to the source's configuration.
-
-  - description: "Content Fetching System"
-    outputPath: "fetcher-system.md"
+  - description: Document Compilation System
+    outputPath: core/document.md
     sources:
       - type: file
-        sourcePaths: [ "src/Fetcher" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          The fetcher subsystem responsible for retrieving and processing content from various sources.
-          It includes the SourceFetcherInterface that defines the contract for all fetchers,
-          FilterableSourceInterface for sources that support content filtering (like by path or content),
-          and SourceFetcherRegistry that manages fetcher selection and execution.
-          This system separates the concerns of source definition (what to fetch) from the actual
-          retrieval process (how to fetch), enabling new source types to be added easily.
-          Fetchers handle various content sources, apply filtering, and prepare content for inclusion in documents.
+        sourcePaths: src/Document
+        filePattern: '*.php'
+        showTreeView: true
 
-  - description: "Document Definition and Compilation"
-    outputPath: "document-processing.md"
+  - description: Source Implementations - File
+    outputPath: sources/file-source.md
     sources:
       - type: file
-        sourcePaths: [ "src/Document", "src" ]
-        filePattern: [ "Document.php", "DocumentsLoaderInterface.php" ]
-        description: >-
-          The Document class represents a compilation target that aggregates content from multiple sources.
-          It defines properties like description, output path, and whether to overwrite existing files.
-          DocumentsLoaderInterface defines the contract for loading document definitions from configuration files.
-          These components form the bridge between configuration and content compilation.
+        sourcePaths: src/Source/File
+        filePattern: '*.php'
+        showTreeView: true
 
-      - type: file
-        sourcePaths: [ "src/Document/Compiler" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          The document compilation system responsible for transforming source definitions into final output documents.
-          DocumentCompiler coordinates fetching content from all sources, applying modifiers, handling errors,
-          and generating the final document output. CompiledDocument represents the result of compilation,
-          while error classes like SourceError and ErrorCollection manage compilation failures.
-          This system implements the core content generation workflow of the Context Generator.
-
-  - description: "Configuration Management System"
-    outputPath: "configuration-system.md"
+  - description: Source Implementations - GitHub
+    outputPath: sources/github-source.md
     sources:
       - type: file
-        sourcePaths: [ "src/ConfigLoader" ]
-        filePattern: [ "*.php" ]
-        notPath: [ "*/Exception/*" ]
-        description: >-
-          The configuration system that loads, parses, and validates Context Generator configurations.
-          ConfigLoaderInterface defines the contract for configuration loaders, while ConfigLoader provides
-          the standard implementation. ConfigLoaderFactory creates appropriate loaders based on configuration format.
-          CompositeConfigLoader supports loading from multiple sources. This system is responsible for
-          reading configuration files and transforming them into usable object structures.
+        sourcePaths: src/Source/Github
+        filePattern: '*.php'
+        showTreeView: true
 
-      - type: file
-        sourcePaths: [ "src/ConfigLoader/Parser", "src/ConfigLoader/Reader", "src/ConfigLoader/Registry" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Specialized components of the configuration system:
-          - Parsers: Transform raw configuration data into structured objects (ConfigParser, ConfigParserPluginInterface)
-          - Readers: Read configuration from different file formats (JsonReader, PhpReader, YamlReader)
-          - Registries: Store and access parsed configuration objects (ConfigRegistry, DocumentRegistry)
-          These components work together to support multiple configuration formats, plugin-based parsing,
-          and structured access to configuration data throughout the application.
-
-  - description: "Content Building and Rendering"
-    outputPath: "lib/content-processing.md"
+  - description: Source Implementations - URL
+    outputPath: sources/url-source.md
     sources:
       - type: file
-        sourcePaths: [ "src/Lib/Content" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          The content processing system responsible for constructing and rendering document content.
-          ContentBuilder provides a fluent API for creating structured content with blocks.
-          ContentBuilderFactory creates builder instances with appropriate configurations.
-          ContentBlock represents a section of content with metadata. This system abstracts
-          content construction from the specific output format, enabling consistent content
-          structure across different renderer implementations.
+        sourcePaths: src/Source/Url
+        filePattern: '*.php'
+        showTreeView: true
 
-      - type: file
-        sourcePaths: [ "src/Lib/Content/Block", "src/Lib/Content/Renderer" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Components for building and rendering structured content:
-          - Blocks: ContentBlock subclasses like CodeBlock, TitleBlock, and TreeViewBlock represent
-            different types of content with specialized formatting and metadata.
-          - Renderers: Transform structured content into specific output formats like Markdown (MarkdownRenderer)
-            or plain text (PlainTextRenderer) through the RendererInterface.
-          These components provide a flexible system for creating richly formatted document content
-          with consistent structure across different output formats.
-
-  - description: "Content Transformation System"
-    outputPath: "modifiers-system.md"
+  - description: Source Implementations - Text
+    outputPath: sources/text-source.md
     sources:
       - type: file
-        sourcePaths: [ "src/Modifier" ]
-        filePattern: [ "*.php" ]
-        notPath: [ "*/Alias/*" ]
-        description: >-
-          The modifier system for transforming source content before inclusion in documents.
-          Modifier represents a named content transformer with options. ModifiersApplier coordinates
-          applying multiple modifiers to content. ModifiersApplierInterface defines the contract for
-          all modifier appliers. Concrete modifiers include:
-          - PhpContentFilter: Extracts specific parts of PHP files (methods, properties, etc.)
-          - PhpSignature: Extracts method signatures from PHP files
-          - AstDocTransformer: Generates documentation from PHP AST
-          - ContextSanitizerModifier: Removes sensitive information from content
-          This system enables flexible content transformation, filtering, and sanitization.
+        sourcePaths: src/Source/Text
+        filePattern: '*.php'
+        showTreeView: true
 
-      - type: file
-        sourcePaths: [ "src/Modifier/Alias" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          The modifier alias subsystem that supports naming and reusing modifier configurations.
-          AliasesRegistry stores and retrieves named modifier configurations.
-          ModifierAliasesParserPlugin handles parsing alias definitions from configuration.
-          ModifierResolver resolves aliases to concrete modifier instances.
-          This system allows defining modifiers once and referencing them by name throughout
-          the configuration, enhancing reusability and maintainability.
-
-  - description: "Command Line Interface"
-    outputPath: "console/commands.md"
+  - description: Source Implementations - Git Diff
+    outputPath: sources/git-diff-source.md
     sources:
       - type: file
-        sourcePaths: [ "src/Console" ]
-        filePattern: [ "*.php" ]
-        notPath: [ "*/Renderer/*" ]
-        description: >-
-          The CLI commands for interacting with the Context Generator:
-          - GenerateCommand: The main command that compiles documents from configuration
-          - InitCommand: Creates initial configuration files for new projects
-          - DisplayCommand: Shows the structure of loaded configurations
-          - SchemaCommand: Manages JSON schema for configuration validation
-          - SelfUpdateCommand: Updates the Context Generator to the latest version
-          - VersionCommand: Displays version information
-          These commands provide the user interface for the Context Generator application
-          and implement the main entry points for its functionality.
+        sourcePaths: src/Source/GitDiff
+        filePattern: '*.php'
+        showTreeView: true
 
-      - type: file
-        sourcePaths: [ "src/Console/Renderer" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Console output rendering components for displaying information to users:
-          - Style: Defines consistent styling for console output
-          - ConfigRendererInterface: Contract for classes that render configuration objects
-          - DocumentRenderer: Renders document configuration information
-          - ModifierRenderer: Renders modifier configuration information
-          - SourceRenderer: Renders source configuration information
-          These components provide a consistent and visually appealing presentation of
-          configuration data and processing results in the console interface.
-
-  - description: "Core Utility Components"
-    outputPath: "lib/utility-components.md"
+  - description: Source Implementations - Composer
+    outputPath: sources/composer-source.md
     sources:
       - type: file
-        sourcePaths: [ "src/Lib/Files.php", "src/FilesInterface.php" ]
-        description: >-
-          File system abstraction layer that provides a consistent API for file operations.
-          FilesInterface defines the contract for file operations like reading, writing, and checking
-          file existence. Files implements this interface for the local filesystem.
-          These components abstract file operations to support different filesystem implementations
-          and facilitate testing.
+        sourcePaths: src/Source/Composer
+        filePattern: '*.php'
+        showTreeView: true
 
-      - type: file
-        sourcePaths: [ "src/Lib/Finder" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          File finding utilities that locate and filter files based on various criteria.
-          FinderInterface defines the contract for finding files from sources.
-          FinderResult represents the result of a find operation with file metadata.
-          These components provide a flexible system for discovering content across
-          different storage mechanisms like local filesystems, GitHub, and Git repositories.
-
-      - type: file
-        sourcePaths: [ "src/Lib/HttpClient" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          HTTP client abstraction for retrieving content from web sources.
-          HttpClientInterface defines the contract for making HTTP requests.
-          HttpResponse represents the result of an HTTP request.
-          Implementations include Psr18Client for standard HTTP requests 
-          and NullHttpClient for testing. This abstraction enables the Context
-          Generator to work with different HTTP client libraries.
-
-      - type: file
-        sourcePaths: [ "src/Lib/Logger" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Logging system for capturing and displaying information about processing.
-          ConsoleLogger outputs log messages to the console with formatting.
-          LogLevel defines severity levels for log messages.
-          HasPrefixLoggerInterface supports prefixed logging for subsystems.
-          These components provide visibility into the inner workings of the
-          Context Generator during execution.
-
-      - type: file
-        sourcePaths: [ "src/Lib/PathFilter" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Path filtering utilities for including and excluding files based on patterns.
-          FilterInterface defines the contract for all path filters.
-          Implementations include ExcludePathFilter, PathFilter, ContentsFilter, and FilePatternFilter.
-          FileHelper provides utility methods for working with file paths.
-          These components support filtering content sources by path, pattern, and content.
-
-      - type: file
-        sourcePaths: [ "src/Lib/Sanitizer" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Content sanitization system for removing sensitive information from source content.
-          RuleInterface defines the contract for sanitization rules.
-          Implementations include KeywordRemovalRule, RegexReplacementRule, and CommentInsertionRule.
-          RuleFactory creates rule instances from configuration.
-          ContextSanitizer applies rules to content.
-          These components ensure that generated documents don't include sensitive information.
-
-      - type: file
-        sourcePaths: [ "src/Lib/Variable" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Variable resolution system for substituting environment and configuration variables.
-          VariableResolver resolves variable references to their values.
-          VariableReplacementProcessor handles replacing variables in text content.
-          Provider classes like DotEnvVariableProvider and PredefinedVariableProvider fetch
-          variable values from different sources. This system enables using environment
-          variables and other dynamic values in configuration files.
-
-  - description: "Fle Source Implementation"
-    outputPath: "source/file-source.md"
+  - description: Source Implementations - Tree
+    outputPath: sources/tree-source.md
     sources:
       - type: file
-        sourcePaths: [ "src/Source/File" ]
-        filePattern: [ "*.php" ]
+        sourcePaths: src/Source/Tree
+        filePattern: '*.php'
+        showTreeView: true
 
-  - description: "Text Source Implementation"
-    outputPath: "source/text-source.md"
+  - description: Modifiers System
+    outputPath: modifiers/modifiers-core.md
     sources:
       - type: file
-        sourcePaths: [ "src/Source/Text" ]
-        filePattern: [ "*.php" ]
+        sourcePaths: src/Modifier
+        filePattern:
+          - '*.php'
+          - 'Alias/*.php'
+        notPath:
+          - 'PhpContentFilter.php'
+          - 'PhpSignature.php'
+          - 'ContextSanitizerModifier.php'
+        showTreeView: true
 
-  - description: "URL Source Implementation"
-    outputPath: "source/url-source.md"
+  - description: PHP Content Modifiers
+    outputPath: modifiers/php-modifiers.md
     sources:
       - type: file
-        sourcePaths: [ "src/Source/Url" ]
-        filePattern: [ "*.php" ]
+        sourcePaths: src/Modifier
+        filePattern:
+          - 'PhpContentFilter.php'
+          - 'PhpSignature.php'
+        showTreeView: true
 
-  - description: "Composer Package Source Implementation"
-    outputPath: "source/composer-source.md"
+  - description: Sanitizer Modifier
+    outputPath: modifiers/sanitizer.md
     sources:
       - type: file
-        sourcePaths: [ "src/Source/Composer" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Composer package source implementation for including content from Composer dependencies.
-          ComposerSource defines the configuration for accessing Composer packages.
-          ComposerSourceFetcher retrieves and processes content from packages.
-          ComposerClientInterface and implementations handle interacting with the Composer ecosystem.
-          Package classes like ComposerPackageInfo and ComposerPackageCollection represent 
-          Composer package metadata. Provider classes locate and load Composer configurations.
-          This specialized source enables including documentation and code from project dependencies.
+        sourcePaths:
+          - src/Modifier/ContextSanitizerModifier.php
+          - src/Lib/Sanitizer
+        filePattern: '*.php'
+        showTreeView: true
 
-  - description: "Git Diff Source Implementation"
-    outputPath: "source/git-diff-source.md"
+  - description: Console Commands
+    outputPath: console/commands.md
     sources:
       - type: file
-        sourcePaths: [ "src/Source/GitDiff" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Git diff source implementation for including changes from Git repositories.
-          CommitDiffSource defines the configuration for accessing Git diffs.
-          CommitDiffSourceFetcher retrieves and processes Git diff content.
-          CommitDiffFinder locates changes based on commit references or time ranges.
-          Fetcher classes like CommitRangeParser interpret Git commit references.
-          Source classes implement different ways of accessing Git content, such as
-          CommitGitSource, StagedGitSource, and StashGitSource.
-          This specialized source enables focusing on recent or specific changes in repositories.
+        sourcePaths: src/Console
+        filePattern: '*Command.php'
+        showTreeView: true
 
-  - description: "GitHub Source Implementation"
-    outputPath: "source/github-source.md"
+  - description: Console Renderers
+    outputPath: console/renderers.md
     sources:
       - type: file
-        sourcePaths: [ "src/Source/Github" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          GitHub source implementation for retrieving content directly from GitHub repositories.
-          GithubSource defines the configuration for accessing GitHub repositories.
-          GithubSourceFetcher retrieves and processes content from GitHub.
-          GithubFinder locates files in GitHub repositories based on patterns.
-          GithubFileInfo represents metadata about files in GitHub repositories.
-          This specialized source enables including content from public or private
-          GitHub repositories without requiring local clones.
+        sourcePaths: src/Console/Renderer
+        filePattern: '*.php'
+        showTreeView: true
 
-  - description: "Tree View Source Implementation"
-    outputPath: "source/tree-source.md"
+  - description: Content Building System
+    outputPath: utilities/content-builder.md
     sources:
       - type: file
-        sourcePaths: [ "src/Source/Tree" ]
-        filePattern: [ "*.php" ]
-        description: >-
-          Tree view source implementation for generating directory structure visualizations.
-          TreeSource defines the configuration for generating tree visualizations.
-          TreeSourceFetcher creates tree visualizations based on directory structures.
-          TreeFinder locates directories and files to include in the tree.
-          This specialized source helps provide context about project structure
-          within generated documents by creating visual directory trees.
+        sourcePaths: src/Lib/Content
+        filePattern: '*.php'
+        showTreeView: true
 
-documents:
-  - description: "Core Source Interfaces and Implementations"
-    outputPath: "source-info.md"
+  - description: Content Block Types
+    outputPath: utilities/content-blocks.md
     sources:
       - type: file
-        sourcePaths: ["src"]
-        filePattern: "SourceInterface.php"
+        sourcePaths: src/Lib/Content/Block
+        filePattern: '*.php'
+        showTreeView: true
+
+  - description: Path Filtering Utilities
+    outputPath: utilities/path-filters.md
+    sources:
       - type: file
-        sourcePaths: ["src/Source"]
-        filePattern: "BaseSource.php"
+        sourcePaths: src/Lib/PathFilter
+        filePattern: '*.php'
+        showTreeView: true
+
+  - description: Tree Building Utilities
+    outputPath: utilities/tree-builder.md
+    sources:
       - type: file
-        sourcePaths: ["src"]
-        filePattern: "Document/DocumentBuilderInterface.php"
+        sourcePaths: src/Lib/TreeBuilder
+        filePattern: '*.php'
+        showTreeView: true
+
+  - description: HTTP Client
+    outputPath: utilities/http-client.md
+    sources:
       - type: file
-        sourcePaths: ["src/Document"]
-        filePattern: "DocumentBuilder.php"
+        sourcePaths: src/Lib/HttpClient
+        filePattern: '*.php'
+        showTreeView: true
+
+  - description: GitHub Client
+    outputPath: utilities/github-client.md
+    sources:
+      - type: file
+        sourcePaths: src/Lib/GithubClient
+        filePattern: '*.php'
+        showTreeView: true
+
+  - description: Variable System
+    outputPath: utilities/variable-system.md
+    sources:
+      - type: file
+        sourcePaths: src/Lib/Variable
+        filePattern: '*.php'
+        showTreeView: true
+
+  - description: Logging System
+    outputPath: utilities/logger.md
+    sources:
+      - type: file
+        sourcePaths: src/Lib/Logger
+        filePattern: '*.php'
+        showTreeView: true
+
+  - description: HTML Utilities
+    outputPath: utilities/html.md
+    sources:
+      - type: file
+        sourcePaths: src/Lib/Html
+        filePattern: '*.php'
+        showTreeView: true

--- a/json-schema.json
+++ b/json-schema.json
@@ -248,6 +248,49 @@
         }
       ]
     },
+    "treeViewConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to show the tree view",
+          "default": true
+        },
+        "showSize": {
+          "type": "boolean",
+          "description": "Include file/directory sizes in the tree",
+          "default": false
+        },
+        "showLastModified": {
+          "type": "boolean",
+          "description": "Include last modified dates in the tree",
+          "default": false
+        },
+        "showCharCount": {
+          "type": "boolean",
+          "description": "Include character counts in the tree",
+          "default": false
+        },
+        "includeFiles": {
+          "type": "boolean",
+          "description": "Whether to include files in the tree or only directories",
+          "default": true
+        },
+        "maxDepth": {
+          "type": "integer",
+          "description": "Maximum depth of the tree to display (0 for unlimited)",
+          "minimum": 0,
+          "default": 0
+        },
+        "dirContext": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional context/descriptions for specific directories"
+        }
+      }
+    },
     "fileSource": {
       "required": [
         "sourcePaths"
@@ -300,6 +343,18 @@
           "type": "boolean",
           "description": "Whether to show directory tree",
           "default": true
+        },
+        "treeView": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Whether to show the tree view"
+            },
+            {
+              "$ref": "#/definitions/treeViewConfig"
+            }
+          ],
+          "description": "Tree view configuration"
         },
         "modifiers": {
           "$ref": "#/definitions/modifiers"
@@ -740,6 +795,21 @@
         "showTreeView": {
           "type": "boolean",
           "description": "Whether to show directory tree visualization"
+        },
+        "treeView": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Whether to show the tree view"
+            },
+            {
+              "$ref": "#/definitions/treeViewConfig"
+            }
+          ],
+          "description": "Tree view configuration"
+        },
+        "modifiers": {
+          "$ref": "#/definitions/modifiers"
         }
       }
     },

--- a/src/Console/Renderer/SourceRenderer.php
+++ b/src/Console/Renderer/SourceRenderer.php
@@ -80,7 +80,7 @@ final class SourceRenderer
         }
 
         $output .= Style::keyValue("Ignore Unreadable Dirs", $source->ignoreUnreadableDirs) . "\n";
-        $output .= Style::keyValue("Show Tree View", $source->showTreeView) . "\n";
+        $output .= Style::keyValue("Show Tree View", $source->treeView->enabled) . "\n";
 
         if (!empty($source->modifiers)) {
             $output .= "\n" . Style::property("Modifiers") . ": " . Style::count(\count($source->modifiers)) . "\n";

--- a/src/Lib/TreeBuilder/TreeViewConfig.php
+++ b/src/Lib/TreeBuilder/TreeViewConfig.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\TreeBuilder;
+
+/**
+ * Configuration container for tree view rendering options
+ */
+final readonly class TreeViewConfig implements \JsonSerializable
+{
+    /**
+     * @param bool $enabled Whether to show the tree view
+     * @param bool $showSize Whether to show file/directory sizes
+     * @param bool $showLastModified Whether to show last modified dates
+     * @param bool $showCharCount Whether to show character counts
+     * @param bool $includeFiles Whether to include files (true) or show only directories (false)
+     * @param int $maxDepth Maximum tree depth to display (0 for unlimited)
+     * @param array<string, string> $dirContext Optional descriptions for specific directories
+     */
+    public function __construct(
+        public bool $enabled = true,
+        public bool $showSize = false,
+        public bool $showLastModified = false,
+        public bool $showCharCount = false,
+        public bool $includeFiles = true,
+        public int $maxDepth = 0,
+        public array $dirContext = [],
+    ) {}
+
+    /**
+     * Create a TreeViewConfig from an array configuration
+     */
+    public static function fromArray(array $data): self
+    {
+        // backward compatibility for old config
+        if (isset($data['showTreeView'])) {
+            return new self(enabled: (bool) $data['showTreeView']);
+        }
+
+        // Handle boolean case (backward compatibility)
+        if (isset($data['treeView']) && \is_bool($data['treeView'])) {
+            return new self(enabled: $data['treeView']);
+        }
+
+        // Handle object/array case
+        $config = $data['treeView'] ?? [];
+        if (!\is_array($config)) {
+            return new self(enabled: (bool) $config);
+        }
+
+        return new self(
+            enabled: $config['enabled'] ?? true,
+            showSize: $config['showSize'] ?? false,
+            showLastModified: $config['showLastModified'] ?? false,
+            showCharCount: $config['showCharCount'] ?? false,
+            includeFiles: $config['includeFiles'] ?? true,
+            maxDepth: $config['maxDepth'] ?? 0,
+            dirContext: $config['dirContext'] ?? [],
+        );
+    }
+
+    /**
+     * Get tree view options as an array
+     */
+    public function getOptions(): array
+    {
+        return [
+            'showSize' => $this->showSize,
+            'showLastModified' => $this->showLastModified,
+            'showCharCount' => $this->showCharCount,
+            'includeFiles' => $this->includeFiles,
+            'maxDepth' => $this->maxDepth,
+            'dirContext' => $this->dirContext,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'enabled' => $this->enabled,
+            'showSize' => $this->showSize,
+            'showLastModified' => $this->showLastModified,
+            'showCharCount' => $this->showCharCount,
+            'includeFiles' => $this->includeFiles === false ? false : null,
+            'maxDepth' => $this->maxDepth > 0 ? $this->maxDepth : null,
+            'dirContext' => !empty($this->dirContext) ? $this->dirContext : null,
+        ], static fn($value) => $value !== null);
+    }
+}

--- a/src/Source/Composer/ComposerSource.php
+++ b/src/Source/Composer/ComposerSource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Source\Composer;
 
 use Butschster\ContextGenerator\Fetcher\FilterableSourceInterface;
+use Butschster\ContextGenerator\Lib\TreeBuilder\TreeViewConfig;
 use Butschster\ContextGenerator\Modifier\Modifier;
 use Butschster\ContextGenerator\Source\SourceWithModifiers;
 
@@ -23,7 +24,7 @@ final class ComposerSource extends SourceWithModifiers implements FilterableSour
      * @param string|array<string> $contains Patterns to include files containing specific content
      * @param string|array<string> $notContains Patterns to exclude files containing specific content
      * @param bool $includeDevDependencies Whether to include dev dependencies
-     * @param bool $showTreeView Whether to show directory tree visualization
+     * @param TreeViewConfig|bool $treeView Tree view configuration or boolean flag
      * @param array<Modifier> $modifiers Identifiers for content modifiers to apply
      * @param array<string> $tags Tags for organization
      */
@@ -37,7 +38,7 @@ final class ComposerSource extends SourceWithModifiers implements FilterableSour
         public readonly string|array $contains = [],
         public readonly string|array $notContains = [],
         public readonly bool $includeDevDependencies = false,
-        public readonly bool $showTreeView = true,
+        public readonly TreeViewConfig|bool $treeView = true,
         array $modifiers = [],
         array $tags = [],
     ) {
@@ -66,7 +67,7 @@ final class ComposerSource extends SourceWithModifiers implements FilterableSour
             contains: $data['contains'] ?? [],
             notContains: $data['notContains'] ?? [],
             includeDevDependencies: $data['includeDevDependencies'] ?? false,
-            showTreeView: $data['showTreeView'] ?? true,
+            treeView: TreeViewConfig::fromArray($data),
             modifiers: $data['modifiers'] ?? [],
             tags: $data['tags'] ?? [],
         );

--- a/src/Source/Composer/ComposerSource.php
+++ b/src/Source/Composer/ComposerSource.php
@@ -24,7 +24,7 @@ final class ComposerSource extends SourceWithModifiers implements FilterableSour
      * @param string|array<string> $contains Patterns to include files containing specific content
      * @param string|array<string> $notContains Patterns to exclude files containing specific content
      * @param bool $includeDevDependencies Whether to include dev dependencies
-     * @param TreeViewConfig|bool $treeView Tree view configuration or boolean flag
+     * @param TreeViewConfig $treeView Tree view configuration or boolean flag
      * @param array<Modifier> $modifiers Identifiers for content modifiers to apply
      * @param array<string> $tags Tags for organization
      */
@@ -38,7 +38,7 @@ final class ComposerSource extends SourceWithModifiers implements FilterableSour
         public readonly string|array $contains = [],
         public readonly string|array $notContains = [],
         public readonly bool $includeDevDependencies = false,
-        public readonly TreeViewConfig|bool $treeView = true,
+        public readonly TreeViewConfig $treeView = new TreeViewConfig(),
         array $modifiers = [],
         array $tags = [],
     ) {

--- a/src/Source/Composer/ComposerSource.php
+++ b/src/Source/Composer/ComposerSource.php
@@ -169,7 +169,7 @@ final class ComposerSource extends SourceWithModifiers implements FilterableSour
             'contains' => $this->contains,
             'notContains' => $this->notContains,
             'includeDevDependencies' => $this->includeDevDependencies,
-            'showTreeView' => $this->showTreeView,
+            'treeView' => $this->treeView,
         ], static fn($value) => $value !== null && $value !== '' && $value !== []);
     }
 }

--- a/src/Source/Composer/ComposerSourceFetcher.php
+++ b/src/Source/Composer/ComposerSourceFetcher.php
@@ -100,7 +100,7 @@ final readonly class ComposerSourceFetcher implements SourceFetcherInterface
         ]);
 
         // Generate a tree view of selected packages if requested
-        if ($source->showTreeView) {
+        if ($source->treeView->enabled) {
             $this->logDebug('Generating package tree view');
             $builder->addTreeView($packages->generateTree());
         }
@@ -170,7 +170,7 @@ final readonly class ComposerSourceFetcher implements SourceFetcherInterface
                     path: $source->path,
                     contains: $source->contains,
                     notContains: $source->notContains,
-                    showTreeView: $source->showTreeView, // Show tree view for individual directories if requested
+                    treeView: $source->treeView, // Show tree view for individual directories if requested
                     modifiers: $source->modifiers,
                 );
 

--- a/src/Source/File/FileSource.php
+++ b/src/Source/File/FileSource.php
@@ -25,7 +25,6 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
      * @param string|array<string> $size Size constraints for files (e.g., '> 10K', '< 1M')
      * @param string|array<string> $date Date constraints for files (e.g., 'since yesterday', '> 2023-01-01')
      * @param bool $ignoreUnreadableDirs Whether to ignore unreadable directories
-     * @param TreeViewConfig|bool $treeView Tree view configuration or boolean flag
      * @param array<Modifier> $modifiers Identifiers for content modifiers to apply
      * @param array<non-empty-string> $tags
      */
@@ -40,7 +39,7 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
         public readonly string|array $size = [],
         public readonly string|array $date = [],
         public readonly bool $ignoreUnreadableDirs = false,
-        public readonly TreeViewConfig|bool $treeView = true,
+        public readonly TreeViewConfig $treeView = new TreeViewConfig(),
         array $modifiers = [],
         array $tags = [],
     ) {

--- a/src/Source/File/FileSource.php
+++ b/src/Source/File/FileSource.php
@@ -249,7 +249,7 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
             'sourcePaths' => $this->sourcePaths,
             'filePattern' => $this->filePattern,
             'notPath' => $this->notPath,
-            'showTreeView' => $this->showTreeView,
+            'treeView' => $this->treeView,
         ];
 
         // Add optional properties only if they're non-empty

--- a/src/Source/File/FileSource.php
+++ b/src/Source/File/FileSource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Source\File;
 
 use Butschster\ContextGenerator\Fetcher\FilterableSourceInterface;
+use Butschster\ContextGenerator\Lib\TreeBuilder\TreeViewConfig;
 use Butschster\ContextGenerator\Modifier\Modifier;
 use Butschster\ContextGenerator\Source\SourceWithModifiers;
 
@@ -24,7 +25,7 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
      * @param string|array<string> $size Size constraints for files (e.g., '> 10K', '< 1M')
      * @param string|array<string> $date Date constraints for files (e.g., 'since yesterday', '> 2023-01-01')
      * @param bool $ignoreUnreadableDirs Whether to ignore unreadable directories
-     * @param bool $showTreeView Whether to show tree view in output
+     * @param TreeViewConfig|bool $treeView Tree view configuration or boolean flag
      * @param array<Modifier> $modifiers Identifiers for content modifiers to apply
      * @param array<non-empty-string> $tags
      */
@@ -39,7 +40,7 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
         public readonly string|array $size = [],
         public readonly string|array $date = [],
         public readonly bool $ignoreUnreadableDirs = false,
-        public readonly bool $showTreeView = true,
+        public readonly TreeViewConfig|bool $treeView = true,
         array $modifiers = [],
         array $tags = [],
     ) {
@@ -88,6 +89,7 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
         // Convert notPath to match Symfony Finder's naming convention
         $notPath = $data['excludePatterns'] ?? $data['notPath'] ?? [];
 
+        // Handle tree view configuration (either boolean or config object)
         return new self(
             sourcePaths: $sourcePaths,
             description: $data['description'] ?? '',
@@ -99,7 +101,7 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
             size: $data['size'] ?? [],
             date: $data['date'] ?? [],
             ignoreUnreadableDirs: $data['ignoreUnreadableDirs'] ?? false,
-            showTreeView: $data['showTreeView'] ?? true,
+            treeView: TreeViewConfig::fromArray($data),
             modifiers: $data['modifiers'] ?? [],
             tags: $data['tags'] ?? [],
         );

--- a/src/Source/File/FileSourceFetcher.php
+++ b/src/Source/File/FileSourceFetcher.php
@@ -55,7 +55,6 @@ readonly class FileSourceFetcher implements SourceFetcherInterface
             'description' => $source->getDescription(),
             'basePath' => $this->basePath,
             'hasModifiers' => !empty($source->modifiers),
-            'showTreeView' => $source->showTreeView,
         ]);
 
         $this->logger?->debug('Creating content builder');
@@ -70,7 +69,7 @@ readonly class FileSourceFetcher implements SourceFetcherInterface
         ]);
 
         try {
-            $finderResult = $this->finder->find($source, $this->basePath);
+            $finderResult = $this->finder->find($source, $this->basePath, $source->treeView->getOptions());
             $fileCount = $finderResult->count();
             $this->logger?->debug('Files found', ['fileCount' => $fileCount]);
         } catch (\Throwable $e) {
@@ -101,7 +100,7 @@ readonly class FileSourceFetcher implements SourceFetcherInterface
         }
 
         // Generate tree view if requested
-        if ($source->showTreeView) {
+        if ($source->treeView->enabled) {
             $this->logger?->debug('Adding tree view to output');
             $builder->addTreeView($finderResult->treeView);
         }

--- a/src/Source/File/SymfonyFinder.php
+++ b/src/Source/File/SymfonyFinder.php
@@ -90,6 +90,11 @@ final readonly class SymfonyFinder implements FinderInterface
             $finder->ignoreUnreadableDirs();
         }
 
+        // Apply depth constraint if maxDepth is set
+        if (isset($options['maxDepth']) && $options['maxDepth'] > 0) {
+            $finder->depth('<= ' . $options['maxDepth']);
+        }
+
         $finder->sortByName();
 
         return new FinderResult(

--- a/src/Source/Tree/TreeSource.php
+++ b/src/Source/Tree/TreeSource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Source\Tree;
 
 use Butschster\ContextGenerator\Fetcher\FilterableSourceInterface;
+use Butschster\ContextGenerator\Lib\TreeBuilder\TreeViewConfig;
 use Butschster\ContextGenerator\Source\BaseSource;
 
 /**
@@ -21,11 +22,7 @@ final class TreeSource extends BaseSource implements FilterableSourceInterface
      * @param string|array<string> $contains Patterns to include files containing specific content
      * @param string|array<string> $notContains Patterns to exclude files containing specific content
      * @param string $renderFormat Output format for the tree (ascii, markdown, json)
-     * @param int $maxDepth Maximum depth of the tree to display (0 for unlimited)
-     * @param bool $includeFiles Whether to include files in the tree or only directories
-     * @param bool $showSize Include file/directory sizes in the tree
-     * @param bool $showLastModified Include last modified dates in the tree
-     * @param array<string, string> $dirContext Optional context/descriptions for specific directories
+     * @param TreeViewConfig|bool $treeView Tree view configuration
      * @param array<non-empty-string> $tags
      */
     public function __construct(
@@ -37,12 +34,7 @@ final class TreeSource extends BaseSource implements FilterableSourceInterface
         public readonly string|array $contains = [],
         public readonly string|array $notContains = [],
         public readonly string $renderFormat = 'ascii',
-        public readonly int $maxDepth = 0,
-        public readonly bool $includeFiles = true,
-        public readonly bool $showSize = false,
-        public readonly bool $showLastModified = false,
-        public readonly bool $showCharCount = false,
-        public readonly array $dirContext = [],
+        public readonly TreeViewConfig|bool $treeView = true,
         array $tags = [],
     ) {
         parent::__construct(description: $description, tags: $tags);
@@ -90,7 +82,7 @@ final class TreeSource extends BaseSource implements FilterableSourceInterface
                 throw new \RuntimeException('renderFormat must be a string');
             }
 
-            $validFormats = ['ascii', 'markdown'];
+            $validFormats = ['ascii'];
             if (!\in_array($data['renderFormat'], $validFormats, true)) {
                 throw new \RuntimeException(
                     \sprintf(
@@ -122,12 +114,14 @@ final class TreeSource extends BaseSource implements FilterableSourceInterface
             contains: $data['contains'] ?? [],
             notContains: $data['notContains'] ?? [],
             renderFormat: $data['renderFormat'] ?? 'ascii',
-            maxDepth: $data['maxDepth'] ?? 0,
-            includeFiles: $data['includeFiles'] ?? true,
-            showSize: $data['showSize'] ?? false,
-            showLastModified: $data['showLastModified'] ?? false,
-            showCharCount: $data['showCharCount'] ?? false,
-            dirContext: $data['dirContext'] ?? [],
+            treeView: new TreeViewConfig(
+                showSize: $data['showSize'] ?? false,
+                showLastModified: $data['showLastModified'] ?? false,
+                showCharCount: $data['showCharCount'] ?? false,
+                includeFiles: $data['includeFiles'] ?? true,
+                maxDepth: $data['maxDepth'] ?? 0,
+                dirContext: $data['dirContext'] ?? [],
+            ),
             tags: $data['tags'] ?? [],
         );
     }

--- a/src/Source/Tree/TreeSource.php
+++ b/src/Source/Tree/TreeSource.php
@@ -203,11 +203,7 @@ final class TreeSource extends BaseSource implements FilterableSourceInterface
             'filePattern' => $this->filePattern,
             'notPath' => $this->notPath,
             'renderFormat' => $this->renderFormat,
-            'maxDepth' => $this->maxDepth,
-            'includeFiles' => $this->includeFiles,
-            'showSize' => $this->showSize,
-            'showLastModified' => $this->showLastModified,
-            'showCharCount' => $this->showCharCount,
+            ...$this->treeView->jsonSerialize(),
         ];
 
         // Add optional properties only if they're non-empty

--- a/src/Source/Tree/TreeSourceFetcher.php
+++ b/src/Source/Tree/TreeSourceFetcher.php
@@ -54,8 +54,6 @@ readonly class TreeSourceFetcher implements SourceFetcherInterface
             'description' => $source->getDescription(),
             'basePath' => $this->basePath,
             'renderFormat' => $source->renderFormat,
-            'maxDepth' => $source->maxDepth,
-            'includeFiles' => $source->includeFiles,
             'hasModifiers' => !empty($source->modifiers),
         ]);
 
@@ -65,17 +63,8 @@ readonly class TreeSourceFetcher implements SourceFetcherInterface
             ->addTitle($source->getDescription());
 
         try {
-            // Build options for the renderer
-            $options = [
-                'showSize' => $source->showSize,
-                'showLastModified' => $source->showLastModified,
-                'showCharCount' => $source->showCharCount,
-                'includeFiles' => $source->includeFiles, // Pass this option to the renderer
-                'dirContext' => $source->dirContext,
-            ];
-
             // Use SymfonyFinder to find files
-            $finderResult = $this->finder->find($source, $this->basePath, $options);
+            $finderResult = $this->finder->find($source, $this->basePath, $source->treeView->getOptions());
 
             // Add content to builder
             $builder->addCodeBlock($finderResult->treeView);

--- a/tests/src/Source/FileSourceConstructorTest.php
+++ b/tests/src/Source/FileSourceConstructorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Source;
 
+use Butschster\ContextGenerator\Lib\TreeBuilder\TreeViewConfig;
 use Butschster\ContextGenerator\Source\File\FileSource;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -37,7 +38,7 @@ class FileSourceConstructorTest extends TestCase
             size: $size,
             date: $date,
             ignoreUnreadableDirs: $ignoreUnreadableDirs,
-            showTreeView: $showTreeView,
+            treeView: new TreeViewConfig($showTreeView),
             modifiers: $modifiers,
         );
 
@@ -51,7 +52,7 @@ class FileSourceConstructorTest extends TestCase
         $this->assertEquals($size, $source->size);
         $this->assertEquals($date, $source->date);
         $this->assertEquals($ignoreUnreadableDirs, $source->ignoreUnreadableDirs);
-        $this->assertEquals($showTreeView, $source->showTreeView);
+        $this->assertEquals($showTreeView, $source->treeView->enabled);
         $this->assertEquals($modifiers, $source->modifiers);
     }
 
@@ -96,7 +97,7 @@ class FileSourceConstructorTest extends TestCase
         $this->assertEquals([], $source->size);
         $this->assertEquals([], $source->date);
         $this->assertFalse($source->ignoreUnreadableDirs);
-        $this->assertTrue($source->showTreeView);
+        $this->assertTrue($source->treeView->enabled);
         $this->assertEquals([], $source->modifiers);
     }
 }

--- a/tests/src/Source/FileSourceFromArrayTest.php
+++ b/tests/src/Source/FileSourceFromArrayTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Source;
 
+use Butschster\ContextGenerator\Lib\TreeBuilder\TreeViewConfig;
 use Butschster\ContextGenerator\Source\File\FileSource;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -23,7 +24,7 @@ class FileSourceFromArrayTest extends TestCase
         $this->assertEquals('', $source->getDescription());
         $this->assertEquals('*.*', $source->filePattern);
         $this->assertEquals([], $source->notPath);
-        $this->assertTrue($source->showTreeView);
+        $this->assertTrue($source->treeView->enabled);
         $this->assertEquals([], $source->modifiers);
     }
 
@@ -57,7 +58,7 @@ class FileSourceFromArrayTest extends TestCase
         $this->assertEquals($data['size'], $source->size);
         $this->assertEquals($data['date'], $source->date);
         $this->assertEquals($data['ignoreUnreadableDirs'], $source->ignoreUnreadableDirs);
-        $this->assertTrue($source->showTreeView);
+        $this->assertTrue($source->treeView->enabled);
         $this->assertEquals($data['modifiers'], $source->modifiers);
     }
 
@@ -160,7 +161,7 @@ class FileSourceFromArrayTest extends TestCase
             size: ['> 10K', '< 1M'],
             date: ['since yesterday'],
             ignoreUnreadableDirs: true,
-            showTreeView: false,
+            treeView: new TreeViewConfig(false),
             modifiers: ['modifier1', 'modifier2'],
         );
 
@@ -176,10 +177,16 @@ class FileSourceFromArrayTest extends TestCase
             'size' => ['> 10K', '< 1M'],
             'date' => ['since yesterday'],
             'ignoreUnreadableDirs' => true,
+            'treeView' => [
+                'enabled' => false,
+                'showSize' => false,
+                'showLastModified' => false,
+                'showCharCount' => false,
+            ],
             'modifiers' => ['modifier1', 'modifier2'],
         ];
 
-        $this->assertEquals($expected, $source->jsonSerialize());
+        $this->assertEquals($expected, \json_decode(\json_encode($source->jsonSerialize()), true));
     }
 
     #[Test]
@@ -195,9 +202,14 @@ class FileSourceFromArrayTest extends TestCase
             'description' => 'Test description',
             'sourcePaths' => 'path/to/file.php',
             'filePattern' => '*.*',
-            'showTreeView' => true,
+            'treeView' => [
+                'enabled' => true,
+                'showSize' => false,
+                'showLastModified' => false,
+                'showCharCount' => false,
+            ],
         ];
 
-        $this->assertEquals($expected, $source->jsonSerialize());
+        $this->assertEquals($expected, \json_decode(\json_encode($source->jsonSerialize()), true));
     }
 }


### PR DESCRIPTION
This PR introduces a more flexible tree view configuration system that allows users to display file metrics in source tree views. 

## What's New


- **TreeViewConfig:** A new container class for all tree view settings
- **Depth Control:** Ability to limit tree depth for cleaner output
- **Directory Context:** Option to add custom descriptions to specific directories
- **Unified Configuration:** Consistent options across different source types

## Example Configuration

```yaml
documents:
  - description: "Project Structure Overview"
    outputPath: "project-structure.md"
    sources:
      - type: file
        sourcePaths: ["src"]
        treeView:
          showSize: true
          showCharCount: true
          includeFiles: true
          maxDepth: 3
          dirContext:
            "src/Controller": "Contains all application controllers"
```

## Example Output

```
Project
├── src/ [4.2 MB, 25,483 chars]
│   ├── Controller/ [756 KB, 7,521 chars] # Contains all application controllers
│   │   ├── ApiController.php [328 KB, 3,845 chars]
│   │   └── WebController.php [428 KB, 3,676 chars]
```

## Backward Compatibility

Existing configurations using `showTreeView: true/false` continue to work as before.