### PR TITLE
Add nested configs import functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     "nette/php-generator": "^4.1",
     "nikic/php-parser": "^v4.0 | ^v5.0",
     "vlucas/phpdotenv": "^5.6",
-    "symfony/yaml": "^7.2",
-    "cycle/database": "^2.12"
+    "symfony/yaml": "^7.2"
   },
   "require-dev": {
     "buggregator/trap": "^1.13",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "nette/php-generator": "^4.1",
     "nikic/php-parser": "^v4.0 | ^v5.0",
     "vlucas/phpdotenv": "^5.6",
-    "symfony/yaml": "^7.2"
+    "symfony/yaml": "^7.2",
+    "cycle/database": "^2.12"
   },
   "require-dev": {
     "buggregator/trap": "^1.13",

--- a/json-schema.json
+++ b/json-schema.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "fileMatch": [
-    "context.json"
+    "context.json",
+    "context.yaml"
   ],
   "id": "https://ctxgithub.com/",
   "title": "ContextHub Configuration",
@@ -11,6 +12,34 @@
     "documents"
   ],
   "properties": {
+    "import": {
+      "type": "array",
+      "description": "List of external configuration files to import",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Path to configuration file (relative to this file)"
+          },
+          {
+            "type": "object",
+            "required": [
+              "path"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path to configuration file (relative to this file)"
+              },
+              "pathPrefix": {
+                "type": "string",
+                "description": "Path prefix to apply to all source paths in the imported configuration"
+              }
+            }
+          }
+        ]
+      }
+    },
     "settings": {
       "type": "object",
       "description": "Global settings for the context generator",

--- a/src/ConfigLoader/ConfigLoader.php
+++ b/src/ConfigLoader/ConfigLoader.php
@@ -61,6 +61,27 @@ final readonly class ConfigLoader implements ConfigLoaderInterface
         }
     }
 
+    /**
+     * Load the raw configuration without processing into a registry
+     */
+    public function loadRawConfig(): array
+    {
+        $this->logger?->debug('Loading raw configuration', [
+            'configFile' => $this->configPath,
+        ]);
+
+        try {
+            // Read configuration using the appropriate reader
+            return $this->reader->read($this->configPath);
+        } catch (\Throwable $e) {
+            // Wrap exceptions in a ConfigLoaderException
+            throw new ConfigLoaderException(
+                \sprintf('Failed to load raw configuration from %s: %s', $this->configPath, $e->getMessage()),
+                previous: $e,
+            );
+        }
+    }
+
     public function isSupported(): bool
     {
         return $this->reader->supports($this->configPath);

--- a/src/ConfigLoader/ConfigLoaderFactory.php
+++ b/src/ConfigLoader/ConfigLoaderFactory.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\ConfigLoader;
 
 use Butschster\ContextGenerator\ConfigLoader\Exception\ConfigLoaderException;
+use Butschster\ContextGenerator\ConfigLoader\Import\ImportResolver;
 use Butschster\ContextGenerator\ConfigLoader\Parser\CompositeConfigParser;
 use Butschster\ContextGenerator\ConfigLoader\Parser\ConfigParser;
 use Butschster\ContextGenerator\ConfigLoader\Parser\ConfigParserPluginInterface;
+use Butschster\ContextGenerator\ConfigLoader\Parser\ImportParserPlugin;
 use Butschster\ContextGenerator\ConfigLoader\Reader\JsonReader;
 use Butschster\ContextGenerator\ConfigLoader\Reader\PhpReader;
 use Butschster\ContextGenerator\ConfigLoader\Reader\StringJsonReader;
@@ -37,6 +39,22 @@ final readonly class ConfigLoaderFactory
     public function create(string $rootPath, array $parserPlugins = []): ConfigLoaderInterface
     {
         \assert($this->logger instanceof HasPrefixLoggerInterface);
+
+        // Create import resolver
+        $importResolver = new ImportResolver(
+            files: $this->files,
+            loaderFactory: $this,
+            logger: $this->logger?->withPrefix('import-resolver'),
+        );
+
+        // Create import parser plugin
+        $importParserPlugin = new ImportParserPlugin(
+            importResolver: $importResolver,
+            logger: $this->logger?->withPrefix('import-parser'),
+        );
+
+        // Add import parser plugin first in the list
+        $parserPlugins = [$importParserPlugin, ...$parserPlugins];
 
         // Create parser
         $parser = new ConfigParser($this->rootPath, $this->logger, ...$parserPlugins);
@@ -100,6 +118,22 @@ final readonly class ConfigLoaderFactory
     public function createForFile(string $filePath, array $parserPlugins = []): ConfigLoaderInterface
     {
         \assert($this->logger instanceof HasPrefixLoggerInterface);
+
+        // Create import resolver
+        $importResolver = new ImportResolver(
+            files: $this->files,
+            loaderFactory: $this,
+            logger: $this->logger?->withPrefix('import-resolver'),
+        );
+
+        // Create import parser plugin
+        $importParserPlugin = new ImportParserPlugin(
+            importResolver: $importResolver,
+            logger: $this->logger?->withPrefix('import-parser'),
+        );
+
+        // Add import parser plugin first in the list
+        $parserPlugins = [$importParserPlugin, ...$parserPlugins];
 
         // Create parser
         $parser = new ConfigParser($this->rootPath, $this->logger, ...$parserPlugins);

--- a/src/ConfigLoader/ConfigLoaderInterface.php
+++ b/src/ConfigLoader/ConfigLoaderInterface.php
@@ -21,6 +21,11 @@ interface ConfigLoaderInterface
     public function load(): DocumentRegistry;
 
     /**
+     * Load raw configuration from the first supported loader
+     */
+    public function loadRawConfig(): array;
+
+    /**
      * Check if this loader can load configuration
      *
      * @return bool True if the loader can load configuration

--- a/src/ConfigLoader/Import/CircularImportDetector.php
+++ b/src/ConfigLoader/Import/CircularImportDetector.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\ConfigLoader\Import;
+
+/**
+ * Detects circular dependencies in imports
+ */
+final class CircularImportDetector
+{
+    /**
+     * @var array<string> Stack of import paths being processed
+     */
+    private array $importStack = [];
+
+    /**
+     * Check if adding this path would create a circular dependency
+     */
+    public function wouldCreateCircularDependency(string $path): bool
+    {
+        return \in_array($path, $this->importStack, true);
+    }
+
+    /**
+     * Begin processing an import path
+     */
+    public function beginProcessing(string $path): void
+    {
+        if ($this->wouldCreateCircularDependency($path)) {
+            throw new \RuntimeException(
+                \sprintf(
+                    'Circular import detected: %s is already being processed. Import stack: %s',
+                    $path,
+                    \implode(' -> ', $this->importStack),
+                ),
+            );
+        }
+
+        $this->importStack[] = $path;
+    }
+
+    /**
+     * Finish processing an import path
+     */
+    public function endProcessing(string $path): void
+    {
+        // Find the path in the stack and remove it and anything after it
+        $index = \array_search($path, $this->importStack, true);
+
+        if ($index !== false) {
+            \array_splice($this->importStack, $index);
+        }
+    }
+}

--- a/src/ConfigLoader/Import/ImportConfig.php
+++ b/src/ConfigLoader/Import/ImportConfig.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\ConfigLoader\Import;
+
+/**
+ * Represents a configuration import directive
+ */
+final readonly class ImportConfig
+{
+    public function __construct(
+        public string $path,
+        public string $absolutePath,
+        public ?string $pathPrefix = null,
+    ) {}
+
+    /**
+     * Create from an array configuration
+     */
+    public static function fromArray(array $config, string $basePath): self
+    {
+        // Handle object format with path and optional pathPrefix
+        if (!isset($config['path'])) {
+            throw new \InvalidArgumentException("Import configuration must have a 'path' property");
+        }
+        $path = $config['path'];
+        $pathPrefix = $config['pathPrefix'] ?? null;
+
+        // Resolve relative path to absolute path
+        $absolutePath = self::resolvePath($path, $basePath);
+
+        return new self(
+            path: $path,
+            absolutePath: $absolutePath,
+            pathPrefix: $pathPrefix,
+        );
+    }
+
+    /**
+     * Resolve a relative path to an absolute path
+     */
+    private static function resolvePath(string $path, string $basePath): string
+    {
+        // If it's an absolute path, use it directly
+        if (\str_starts_with($path, '/')) {
+            return $path;
+        }
+
+        // Otherwise, resolve it relative to the base path
+        return \rtrim($basePath, '/') . '/' . $path;
+    }
+}

--- a/src/ConfigLoader/Import/ImportResolver.php
+++ b/src/ConfigLoader/Import/ImportResolver.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\ConfigLoader\Import;
+
+use Butschster\ContextGenerator\ConfigLoader\ConfigLoaderFactory;
+use Butschster\ContextGenerator\ConfigLoader\Exception\ConfigLoaderException;
+use Butschster\ContextGenerator\FilesInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves import directives in configuration files
+ */
+final readonly class ImportResolver
+{
+    public function __construct(
+        private FilesInterface $files,
+        private ConfigLoaderFactory $loaderFactory,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Process imports in a configuration
+     *
+     * @param array<mixed> $config The configuration containing imports
+     * @param string $basePath The base path for resolving relative paths
+     * @param array<string> $parsedImports Already processed import paths to avoid duplicates
+     * @param CircularImportDetector $detector Circular import detector
+     * @return array<mixed> The merged configuration with imports processed
+     */
+    public function resolveImports(
+        array $config,
+        string $basePath,
+        array &$parsedImports = [],
+        ?CircularImportDetector $detector = null,
+    ): array {
+        // Initialize circular import detector if not provided
+        $detector ??= new CircularImportDetector();
+
+        // If no imports, return the original config
+        if (!isset($config['import']) || empty($config['import'])) {
+            return $config;
+        }
+
+        $imports = $config['import'];
+        if (!\is_array($imports)) {
+            throw new ConfigLoaderException('The "import" property must be an array');
+        }
+
+        // Process each import
+        $importedConfigs = [];
+        foreach ($imports as $importConfig) {
+            $importCfg = ImportConfig::fromArray($importConfig, $basePath);
+
+            // Skip if already processed
+            if (\in_array($importCfg->absolutePath, $parsedImports, true)) {
+                $this->logger?->debug('Skipping already processed import', [
+                    'path' => $importCfg->path,
+                    'absolutePath' => $importCfg->absolutePath,
+                ]);
+                continue;
+            }
+
+            // Check for circular imports
+            $detector->beginProcessing($importCfg->absolutePath);
+
+            try {
+                // Load the import configuration
+                $importedConfig = $this->loadImportConfig($importCfg);
+
+                // Recursively process nested imports
+                $dirname = \dirname($importCfg->absolutePath);
+                $importedConfig = $this->resolveImports(
+                    $importedConfig,
+                    $dirname,
+                    $parsedImports,
+                    $detector,
+                );
+
+                // Apply path prefix if specified
+                $importedConfig = $this->applyPathPrefix($importedConfig, \dirname((string) $importConfig['path']));
+
+                // Store for later merging
+                $importedConfigs[] = $importedConfig;
+
+                // Mark as processed
+                $parsedImports[] = $importCfg->absolutePath;
+
+                $this->logger?->debug('Successfully processed import', [
+                    'path' => $importCfg->path,
+                    'absolutePath' => $importCfg->absolutePath,
+                ]);
+            } finally {
+                // Always end processing to maintain stack integrity
+                $detector->endProcessing($importCfg->absolutePath);
+            }
+        }
+
+        // Remove the import directive from the original config
+        unset($config['import']);
+
+        // Merge all configurations
+        return $this->mergeConfigurations([$config, ...$importedConfigs]);
+    }
+
+    /**
+     * Load an import configuration
+     */
+    private function loadImportConfig(ImportConfig $importConfig): array
+    {
+        if (!$this->files->exists($importConfig->absolutePath)) {
+            throw new ConfigLoaderException(
+                \sprintf('Import file not found: %s', $importConfig->absolutePath),
+            );
+        }
+
+        try {
+            $loader = $this->loaderFactory->createForFile($importConfig->absolutePath);
+
+            if (!$loader->isSupported()) {
+                throw new ConfigLoaderException(
+                    \sprintf('Unsupported import file format: %s', $importConfig->absolutePath),
+                );
+            }
+
+            // Load the raw configuration (before registry conversion)
+            return $loader->loadRawConfig();
+        } catch (\Throwable $e) {
+            throw new ConfigLoaderException(
+                \sprintf('Failed to load import file %s: %s', $importConfig->absolutePath, $e->getMessage()),
+                previous: $e,
+            );
+        }
+    }
+
+    /**
+     * Apply path prefix to relevant source paths
+     */
+    private function applyPathPrefix(array $config, string $pathPrefix): array
+    {
+        // Apply to documents array
+        if (isset($config['documents']) && \is_array($config['documents'])) {
+            foreach ($config['documents'] as &$document) {
+                if (isset($document['sources']) && \is_array($document['sources'])) {
+                    foreach ($document['sources'] as &$source) {
+                        $source = $this->applyPathPrefixToSource($source, $pathPrefix);
+                    }
+                }
+            }
+        }
+
+        // Also consider global pathPrefix
+        if (isset($config['pathPrefix'])) {
+            $config['pathPrefix'] = $this->combinePaths($pathPrefix, $config['pathPrefix']);
+        } else {
+            $config['pathPrefix'] = $pathPrefix;
+        }
+
+        return $config;
+    }
+
+    /**
+     * Apply path prefix to a source configuration
+     */
+    private function applyPathPrefixToSource(array $source, string $prefix): array
+    {
+        // Handle sourcePaths property
+        if (isset($source['sourcePaths'])) {
+            $source['sourcePaths'] = $this->applyPrefixToPaths($source['sourcePaths'], $prefix);
+        }
+
+        // Handle repository property (for git_diff source)
+        if (isset($source['repository']) && $source['type'] === 'git_diff') {
+            // Only prefix if it's a relative path
+            if (!\str_starts_with($source['repository'], '/')) {
+                $source['repository'] = $this->combinePaths($prefix, $source['repository']);
+            }
+        }
+
+        // Handle composerPath property (for composer source)
+        if (isset($source['composerPath']) && $source['type'] === 'composer') {
+            if (!\str_starts_with($source['composerPath'], '/')) {
+                $source['composerPath'] = $this->combinePaths($prefix, $source['composerPath']);
+            }
+        }
+
+        return $source;
+    }
+
+    /**
+     * Apply prefix to path(s)
+     */
+    private function applyPrefixToPaths(mixed $paths, string $prefix): mixed
+    {
+        if (\is_string($paths)) {
+            // Skip absolute paths
+            if (\str_starts_with($paths, '/')) {
+                return $paths;
+            }
+            return $this->combinePaths($prefix, $paths);
+        }
+
+        if (\is_array($paths)) {
+            $result = [];
+            foreach ($paths as $path) {
+                $result[] = $this->applyPrefixToPaths($path, $prefix);
+            }
+            return $result;
+        }
+
+        // If it's not a string or array, return as is
+        return $paths;
+    }
+
+    /**
+     * Combine two paths with a separator
+     */
+    private function combinePaths(string $prefix, string $path): string
+    {
+        return \rtrim($prefix, '/') . '/' . \ltrim($path, '/');
+    }
+
+    /**
+     * Merge multiple configurations
+     */
+    private function mergeConfigurations(array $configs): array
+    {
+        $result = [];
+
+        foreach ($configs as $config) {
+            // Special handling for documents array - append instead of replace
+            if (isset($config['documents']) && \is_array($config['documents'])) {
+                $result['documents'] = \array_merge(
+                    $result['documents'] ?? [],
+                    $config['documents'],
+                );
+                unset($config['documents']);
+            }
+
+            // Merge the rest of the configuration
+            $result = \array_merge($result, $config);
+        }
+
+        return $result;
+    }
+}

--- a/src/ConfigLoader/Parser/ConfigParserPluginInterface.php
+++ b/src/ConfigLoader/Parser/ConfigParserPluginInterface.php
@@ -17,6 +17,18 @@ interface ConfigParserPluginInterface
     public function getConfigKey(): string;
 
     /**
+     * Update the configuration array before parsing
+     *
+     * This allows plugins to modify configuration by importing or transforming it.
+     * Return the original array if no changes are needed.
+     *
+     * @param array<mixed> $config The current configuration array
+     * @param string $rootPath The root path for resolving relative paths
+     * @return array<mixed> The updated configuration array
+     */
+    public function updateConfig(array $config, string $rootPath): array;
+
+    /**
      * Parse the configuration section and return a registry
      *
      * @param array<mixed> $config The full configuration array

--- a/src/ConfigLoader/Parser/ImportParserPlugin.php
+++ b/src/ConfigLoader/Parser/ImportParserPlugin.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\ConfigLoader\Parser;
+
+use Butschster\ContextGenerator\ConfigLoader\Import\ImportResolver;
+use Butschster\ContextGenerator\ConfigLoader\Registry\RegistryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Plugin for processing import directives in configuration
+ */
+final readonly class ImportParserPlugin implements ConfigParserPluginInterface
+{
+    public function __construct(
+        private ImportResolver $importResolver,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function getConfigKey(): string
+    {
+        return 'import';
+    }
+
+    public function parse(array $config, string $rootPath): ?RegistryInterface
+    {
+        // We don't create a registry here, we just update the config
+        // via the updateConfig method
+        return null;
+    }
+
+    public function supports(array $config): bool
+    {
+        return isset($config['import']) && \is_array($config['import']);
+    }
+
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // If no imports, return the original config
+        if (!$this->supports($config)) {
+            return $config;
+        }
+
+        $this->logger?->debug('Processing imports', [
+            'rootPath' => $rootPath,
+            'importCount' => \count($config['import']),
+        ]);
+
+        // Process imports and return the merged configuration
+        $processedConfig = $this->importResolver->resolveImports($config, $rootPath);
+
+        $this->logger?->debug('Imports processed successfully', [
+            'documentCount' => isset($processedConfig['documents']) ? \count($processedConfig['documents']) : 0,
+        ]);
+
+        return $processedConfig;
+    }
+}

--- a/src/Document/DocumentsParserPlugin.php
+++ b/src/Document/DocumentsParserPlugin.php
@@ -39,6 +39,12 @@ final readonly class DocumentsParserPlugin implements ConfigParserPluginInterfac
         return isset($config['documents']) && \is_array($config['documents']);
     }
 
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // By default, return the config unchanged
+        return $config;
+    }
+
     public function parse(array $config, string $rootPath): ?RegistryInterface
     {
         if (!$this->supports($config)) {

--- a/src/Modifier/Alias/ModifierAliasesParserPlugin.php
+++ b/src/Modifier/Alias/ModifierAliasesParserPlugin.php
@@ -28,6 +28,12 @@ final readonly class ModifierAliasesParserPlugin implements ConfigParserPluginIn
             && \is_array($config['settings']['modifiers']);
     }
 
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // By default, return the config unchanged
+        return $config;
+    }
+
     public function parse(array $config, string $rootPath): ?RegistryInterface
     {
         if (!$this->supports($config)) {


### PR DESCRIPTION
This PR implements the configuration import functionality as specified in the RFC. It allows splitting configuration across multiple files, which helps organize large projects with multiple code bases or services.

## Features

- **Import Directive**: Added support for specifying external configuration files to import
- **Recursive Imports**: Support for nested imports (configs importing other configs)
- **Relative Path Resolution**: Import paths are resolved relative to the importing file
- **Circular Import Detection**: Prevention of circular dependencies

## Examples

Users can now import configurations:

```yaml
import:
  - path: services/api/context.yaml

documents:
  - description: Project Overview
    outputPath: docs/overview.md
    sources:
      - type: text
        content: |
          # Project Documentation
          
          This is the main project documentation.
```