### PR TITLE
Fix typo in security.yml posi -> posix

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
         uses: shivammathur/setup-php@2.32.0
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: none, ctype, curl, dom, json, mbstring, phar, simplexml, tokenizer, xml, xmlwriter, sockets, opcache, pcntl, posi
+          extensions: none, ctype, curl, dom, json, mbstring, phar, simplexml, tokenizer, xml, xmlwriter, sockets, opcache, pcntl, posix
           ini-values: error_reporting=E_ALL
           coverage: none
 


### PR DESCRIPTION
I bet it should be `posix` instead of `posi`?