### PR TITLE
JSON Schema Support for IDE Autocompletion

### DIFF
--- a/src/Application/JsonSchema.php
+++ b/src/Application/JsonSchema.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Application;
 
-final readonly class JsonSchema {
+final readonly class JsonSchema
+{
     /**
      * The URL where the JSON schema is hosted
      */

--- a/src/Application/JsonSchema.php
+++ b/src/Application/JsonSchema.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Application;
+
+final readonly class JsonSchema {
+    /**
+     * The URL where the JSON schema is hosted
+     */
+    public const string SCHEMA_URL = 'https://raw.githubusercontent.com/context-hub/generator/refs/heads/main/json-schema.json';
+}

--- a/src/Config/Registry/ConfigRegistry.php
+++ b/src/Config/Registry/ConfigRegistry.php
@@ -7,10 +7,14 @@ namespace Butschster\ContextGenerator\Config\Registry;
 /**
  * Container for all registries
  */
-final class ConfigRegistry
+final class ConfigRegistry implements \JsonSerializable
 {
     /** @var array<string, RegistryInterface> */
     private array $registries = [];
+
+    public function __construct(
+        private ?string $schema = null,
+    ) {}
 
     /**
      * Register a new registry
@@ -64,5 +68,21 @@ final class ConfigRegistry
     public function all(): array
     {
         return $this->registries;
+    }
+
+    public function jsonSerialize(): array
+    {
+        $data = [
+            '$schema' => $this->schema,
+        ];
+
+        foreach ($this->registries as $type => $registry) {
+            $data[$type] = $registry;
+        }
+
+        return \array_filter(
+            $data,
+            static fn($value) => $value !== null && $value !== [],
+        );
     }
 }

--- a/src/Config/Registry/ConfigRegistry.php
+++ b/src/Config/Registry/ConfigRegistry.php
@@ -13,7 +13,7 @@ final class ConfigRegistry implements \JsonSerializable
     private array $registries = [];
 
     public function __construct(
-        private ?string $schema = null,
+        private readonly ?string $schema = null,
     ) {}
 
     /**

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Console;
 
+use Butschster\ContextGenerator\Application\JsonSchema;
 use Butschster\ContextGenerator\Config\ConfigType;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistry;
 use Butschster\ContextGenerator\Directories;
 use Butschster\ContextGenerator\Document\Document;
 use Butschster\ContextGenerator\Document\DocumentRegistry;
@@ -51,7 +53,11 @@ final class InitCommand extends BaseCommand
             return Command::FAILURE;
         }
 
-        $content = new DocumentRegistry([
+        $config = new ConfigRegistry(
+            schema: JsonSchema::SCHEMA_URL,
+        );
+
+        $config->register(new DocumentRegistry([
             new Document(
                 description: 'Project structure overview',
                 outputPath: 'project-structure.md',
@@ -62,13 +68,13 @@ final class InitCommand extends BaseCommand
                     ),
                 ),
             ),
-        ]);
+        ]));
 
         try {
             $content = match ($type) {
-                ConfigType::Json => \json_encode($content, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+                ConfigType::Json => \json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
                 ConfigType::Yaml => Yaml::dump(
-                    \json_decode(\json_encode($content), true),
+                    \json_decode(\json_encode($config), true),
                     10,
                     2,
                     Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK,

--- a/src/Console/SchemaCommand.php
+++ b/src/Console/SchemaCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Console;
 
+use Butschster\ContextGenerator\Application\JsonSchema;
 use Butschster\ContextGenerator\Directories;
 use Butschster\ContextGenerator\Lib\HttpClient\Exception\HttpException;
 use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
@@ -19,11 +20,6 @@ use Symfony\Component\Console\Command\Command;
 )]
 final class SchemaCommand extends BaseCommand
 {
-    /**
-     * The URL where the JSON schema is hosted
-     */
-    private const string SCHEMA_URL = 'https://raw.githubusercontent.com/context-hub/generator/refs/heads/main/json-schema.json';
-
     #[Option(
         name: 'download',
         shortcut: 'd',
@@ -49,7 +45,7 @@ final class SchemaCommand extends BaseCommand
         $outputPath = $dirs->getFilePath($this->outputPath);
 
         // Always show the URL where the schema is hosted
-        $this->output->info('JSON schema URL: ' . self::SCHEMA_URL);
+        $this->output->info('JSON schema URL: ' . JsonSchema::SCHEMA_URL);
 
         // If no download requested, exit early
         if (!$this->download) {
@@ -59,7 +55,7 @@ final class SchemaCommand extends BaseCommand
 
         // Download and save the schema
         try {
-            $response = $httpClient->get(self::SCHEMA_URL, [
+            $response = $httpClient->get(JsonSchema::SCHEMA_URL, [
                 'User-Agent' => 'Context-Generator-Schema-Download',
                 'Accept' => 'application/json',
             ]);

--- a/src/Document/DocumentRegistry.php
+++ b/src/Document/DocumentRegistry.php
@@ -38,8 +38,6 @@ final class DocumentRegistry implements RegistryInterface
 
     public function jsonSerialize(): array
     {
-        return [
-            'documents' => $this->documents,
-        ];
+        return $this->documents;
     }
 }


### PR DESCRIPTION
This PR adds JSON Schema support to config files, helping developers with autocompletion in their IDEs.

- Added `$schema` attribute to generated config files, pointing to our hosted JSON schema

```yaml
$schema: 'https://raw.githubusercontent.com/context-hub/generator/refs/heads/main/json-schema.json'

documents:
  - ...
```