### PR TITLE
 Support `ctx --version` command

### DIFF
--- a/app.php
+++ b/app.php
@@ -14,7 +14,7 @@ use Spiral\Core\Options;
 //  Prepare Global Environment
 // -----------------------------------------------------------------------------
 \mb_internal_encoding('UTF-8');
-\error_reporting((E_ALL | E_STRICT) ^ E_DEPRECATED);
+\error_reporting(E_ALL ^ E_DEPRECATED);
 
 
 // -----------------------------------------------------------------------------
@@ -64,10 +64,8 @@ $vendorPath = (static function (): string {
 $insidePhar = \str_starts_with(__FILE__, 'phar://');
 $vendorPath = \dirname($vendorPath) . '/../';
 $versionFile = $vendorPath . '/version.json';
-$appPath = \realpath($vendorPath);
-if ($insidePhar) {
-    $appPath = \getcwd();
-}
+$appPath = $insidePhar ? \getcwd() : \realpath($vendorPath);
+
 $version = \file_exists($versionFile)
     ? \json_decode(\file_get_contents($versionFile), true)
     : [

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "spiral/code-style": "^2.2.2",
     "phpunit/phpunit": "^10.2",
     "rector/rector": "^2.0",
-    "vimeo/psalm": "^5.8"
+    "vimeo/psalm": "^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Application/Bootloader/ConsoleBootloader.php
+++ b/src/Application/Bootloader/ConsoleBootloader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Application\Bootloader;
 
+use Butschster\ContextGenerator\Application\Application;
 use Butschster\ContextGenerator\Application\Dispatcher\ConsoleDispatcher;
 use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Bootloader\Bootloader;
@@ -23,7 +24,7 @@ final class ConsoleBootloader extends Bootloader
         private readonly ConfiguratorInterface $config,
     ) {}
 
-    public function init(AbstractKernel $kernel, BinderInterface $binder): void
+    public function init(AbstractKernel $kernel, BinderInterface $binder, Application $app): void
     {
         $kernel->bootstrapped(static function (AbstractKernel $kernel): void {
             $kernel->addDispatcher(ConsoleDispatcher::class);
@@ -41,6 +42,8 @@ final class ConsoleBootloader extends Bootloader
             [
                 'interceptors' => [],
                 'commands' => [],
+                'name' => $app->name,
+                'version' => $app->version,
             ],
         );
     }


### PR DESCRIPTION
Fix PHP 8.4 compatibility
- Remove deprecated `E_STRICT`
- Update psalm to v6

Support `ctx --version` command