### PR TITLE
Platform-Specific Binary Downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .php_cs.cache
 .phpunit.result.cache
 .build
+.output
 composer.lock
 coverage
 docs

--- a/build-binary.sh
+++ b/build-binary.sh
@@ -4,9 +4,12 @@ set -e
 echo "Building Context Generator Docker image..."
 docker build -t context-generator .
 
+rm -rf .output
+mkdir -p .output
+
 echo "Extracting build artifacts..."
 CONTAINER_ID=$(docker create context-generator)
-docker cp $CONTAINER_ID:/app/.build/bin/ctx ./.output
+docker cp $CONTAINER_ID:/.output/ctx ./.output/ctx
 docker rm $CONTAINER_ID
 
 echo "Build complete! Artifacts available in ./output directory:"

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "cs-check": "vendor/bin/php-cs-fixer fix --dry-run",
     "cs-fix": "vendor/bin/php-cs-fixer fix",
     "psalm": "vendor/bin/psalm --config=psalm.xml ./src",
-    "psalm:ci": "psalm --output-format=github --shepherd --show-info=false --stats --threads=4",
+    "psalm:ci": "vendor/bin/psalm --config=psalm.xml ./src --output-format=github --shepherd --show-info=false --stats --threads=4 --no-cache",
     "refactor": "rector process --config=rector.php",
     "refactor:ci": "rector process --config=rector.php --dry-run --ansi",
     "test": "vendor/bin/phpunit",
@@ -74,5 +74,10 @@
     ]
   },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "config": {
+    "allow-plugins": {
+      "spiral/composer-publish-plugin": false
+    }
+  }
 }

--- a/src/Application/FSPath.php
+++ b/src/Application/FSPath.php
@@ -387,7 +387,7 @@ final class FSPath implements \Stringable
 
         // Resolve special path segments
         $parts = \array_filter(
-            \explode(self::getDirectorySeparator(), (string) $path),
+            \explode(self::getDirectorySeparator(), $path),
             static fn($part) => $part !== '',
         );
         $result = [];

--- a/src/Application/FSPath.php
+++ b/src/Application/FSPath.php
@@ -385,9 +385,11 @@ final class FSPath implements \Stringable
         // Determine if the path is absolute
         $isAbsolute = self::_isAbsolute($path);
 
-        // Resolve special path segments
+        /**
+         * Resolve special path segments
+         * @psalm-suppress RedundantCast
+         */
         $parts = \array_filter(
-            /** @psalm-suppress RedundantCast */
             \explode(self::getDirectorySeparator(), (string) $path),
             static fn($part) => $part !== '',
         );

--- a/src/Application/FSPath.php
+++ b/src/Application/FSPath.php
@@ -387,7 +387,8 @@ final class FSPath implements \Stringable
 
         // Resolve special path segments
         $parts = \array_filter(
-            \explode(self::getDirectorySeparator(), $path),
+            /** @psalm-suppress RedundantCast */
+            \explode(self::getDirectorySeparator(), (string) $path),
             static fn($part) => $part !== '',
         );
         $result = [];

--- a/src/Application/Logger/FileLogger.php
+++ b/src/Application/Logger/FileLogger.php
@@ -10,13 +10,18 @@ use Monolog\Logger;
 use Monolog\Processor\TagProcessor;
 
 /**
- * @psalm-suppress all
+ * @psalm-suppress InvalidExtendClass
  */
 final class FileLogger extends Logger implements HasPrefixLoggerInterface
 {
     /**
      * @param non-empty-string $name
      * @param non-empty-string $filePath
+     * @psalm-suppress ImplementedParamTypeMismatch
+     * @psalm-suppress ConstructorSignatureMismatch
+     * @psalm-suppress ParamNameMismatch
+     * @psalm-suppress MethodSignatureMismatch
+     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function __construct(string $name, string $filePath, Level $level)
     {

--- a/src/Console/Renderer/Style.php
+++ b/src/Console/Renderer/Style.php
@@ -59,7 +59,7 @@ final class Style
         }
 
         if (\is_numeric($value)) {
-            return "\033[0;36m" . $value . "\033[0m";
+            return "\033[0;36m" . (string) $value . "\033[0m";
         }
 
         return (string) $value;

--- a/src/Lib/BinaryUpdater/BinaryUpdater.php
+++ b/src/Lib/BinaryUpdater/BinaryUpdater.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\BinaryUpdater;
+
+use Butschster\ContextGenerator\Lib\BinaryUpdater\Strategy\UpdateStrategyInterface;
+use Psr\Log\LoggerInterface;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Handles binary file updates, especially for self-update operations.
+ * Uses different strategies based on the operating system to handle
+ * the "file busy" scenario when updating a running binary.
+ */
+final readonly class BinaryUpdater
+{
+    public function __construct(
+        private FilesInterface $files,
+        private UpdateStrategyInterface $strategy,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Update a binary file, handling the case where the target file is currently in use.
+     *
+     * @param string $sourcePath Path to the source file containing the update
+     * @param string $targetPath Path to the target binary that needs to be updated
+     * @param bool $createDirectory Whether to create the target directory if it doesn't exist
+     * @return bool Whether the update process was started successfully
+     */
+    public function update(string $sourcePath, string $targetPath, bool $createDirectory = true): bool
+    {
+        // Log the update attempt
+        $this->logger?->info("Attempting to update binary: {$targetPath}");
+
+        // Create the target directory if needed
+        if ($createDirectory) {
+            $targetDir = \dirname($targetPath);
+            $this->files->ensureDirectory($targetDir);
+        }
+
+        // Try direct update first (might work if file is not in use)
+        try {
+            $this->logger?->info("Trying direct file update...");
+
+            // On Windows, we need to delete the file first
+            if (\PHP_OS_FAMILY === 'Windows' && $this->files->exists($targetPath)) {
+                $this->files->delete($targetPath);
+            }
+
+            // Read source content
+            $content = $this->files->read($sourcePath);
+
+            // Write to target
+            $this->files->write($targetPath, $content);
+
+            // Make executable (except on Windows)
+            if (\PHP_OS_FAMILY !== 'Windows') {
+                \chmod($targetPath, 0755);
+            }
+
+            $this->logger?->info("Direct update successful");
+            return true;
+        } catch (\Throwable $e) {
+            // If direct update fails, try using platform-specific strategy
+            $this->logger?->info("Direct update failed: {$e->getMessage()}");
+            $this->logger?->info("Trying platform-specific update strategy...");
+
+            // Execute the update
+            return $this->strategy->update($sourcePath, $targetPath);
+        }
+    }
+}

--- a/src/Lib/BinaryUpdater/BinaryUpdater.php
+++ b/src/Lib/BinaryUpdater/BinaryUpdater.php
@@ -53,7 +53,9 @@ final readonly class BinaryUpdater
             $content = $this->files->read($sourcePath);
 
             // Write to target
-            $this->files->write($targetPath, $content);
+            if (!$this->files->write($targetPath, $content)) {
+                throw new \RuntimeException(\sprintf("Failed to write to target file: %s", $targetPath));
+            }
 
             // Make executable (except on Windows)
             if (\PHP_OS_FAMILY !== 'Windows') {

--- a/src/Lib/BinaryUpdater/Strategy/UnixUpdateStrategy.php
+++ b/src/Lib/BinaryUpdater/Strategy/UnixUpdateStrategy.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\BinaryUpdater\Strategy;
+
+use Psr\Log\LoggerInterface;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Unix-specific strategy for updating binary files.
+ * Creates a bash script that runs in the background after the current process exits.
+ */
+final readonly class UnixUpdateStrategy implements UpdateStrategyInterface
+{
+    public function __construct(
+        private FilesInterface $files,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function update(string $sourcePath, string $targetPath): bool
+    {
+        // Create the update script
+        $scriptPath = $this->createUpdateScript($sourcePath, $targetPath);
+
+        if ($scriptPath === null) {
+            return false;
+        }
+
+        // Make the script executable
+        if (!\chmod($scriptPath, 0755)) {
+            return false;
+        }
+
+        // Run the script in the background and continue after PHP exits
+        $command = \sprintf(
+            'nohup %s > /dev/null 2>&1 & echo $!',
+            \escapeshellarg($scriptPath),
+        );
+
+        // Execute the command and capture the process ID
+        $output = [];
+        $resultCode = 0;
+        \exec($command, $output, $resultCode);
+
+        // If we got a process ID and the command executed successfully, consider it a success
+        return $resultCode === 0 && !empty($output[0]) && \is_numeric($output[0]);
+    }
+
+    /**
+     * Create a temporary bash script that will perform the update.
+     *
+     * @return string|null Path to the created script, or null if creation failed
+     */
+    private function createUpdateScript(string $sourcePath, string $targetPath): ?string
+    {
+        $scriptPath = $this->files->tempFilename('.sh');
+
+        try {
+            $scriptContent = <<<BASH
+                #!/bin/bash
+                
+                # Wait for the parent process to exit
+                sleep 1
+                
+                # Define paths
+                SOURCE="{$sourcePath}"
+                TARGET="{$targetPath}"
+                TARGET_DIR="\$(dirname "\$TARGET")"
+                
+                # Set up retry logic
+                MAX_ATTEMPTS=10
+                ATTEMPT=1
+                SUCCESS=0
+                
+                echo "Starting update process for \$TARGET"
+                
+                # Create the target directory if it doesn't exist
+                mkdir -p "\$TARGET_DIR"
+                
+                # Try to update the file with multiple attempts
+                while [ \$ATTEMPT -le \$MAX_ATTEMPTS ] && [ \$SUCCESS -eq 0 ]; do
+                    echo "Attempt \$ATTEMPT: Trying to update \$TARGET"
+                
+                    # Try to copy the file
+                    if cp "\$SOURCE" "\$TARGET" 2>/dev/null; then
+                        # Make the file executable
+                        chmod 755 "\$TARGET"
+                        echo "Update successful!"
+                        SUCCESS=1
+                    else
+                        echo "Binary busy or permission denied, waiting 2 seconds..."
+                        sleep 2
+                        ATTEMPT=\$((ATTEMPT+1))
+                    fi
+                done
+                
+                # Clean up the temporary source file
+                rm -f "\$SOURCE"
+                rm -f "$scriptPath"
+                
+                # Exit with the appropriate status
+                if [ \$SUCCESS -eq 0 ]; then
+                    echo "Update failed after \$MAX_ATTEMPTS attempts."
+                    exit 1
+                fi
+                
+                exit 0
+                BASH;
+
+            $this->files->write($scriptPath, $scriptContent);
+            return $scriptPath;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Lib/BinaryUpdater/Strategy/UpdateStrategyInterface.php
+++ b/src/Lib/BinaryUpdater/Strategy/UpdateStrategyInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\BinaryUpdater\Strategy;
+
+/**
+ * Interface for platform-specific binary update strategies.
+ */
+interface UpdateStrategyInterface
+{
+    /**
+     * Update a binary file, handling the case where the file is currently in use.
+     * This typically involves creating an external script that runs after the
+     * current process exits.
+     *
+     * @return bool Whether the update process was started successfully
+     */
+    public function update(string $sourcePath, string $targetPath): bool;
+}

--- a/src/Lib/BinaryUpdater/Strategy/WindowsUpdateStrategy.php
+++ b/src/Lib/BinaryUpdater/Strategy/WindowsUpdateStrategy.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\BinaryUpdater\Strategy;
+
+use Psr\Log\LoggerInterface;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Windows-specific strategy for updating binary files.
+ * Creates a batch script that runs in the background after the current process exits.
+ */
+final readonly class WindowsUpdateStrategy implements UpdateStrategyInterface
+{
+    public function __construct(
+        private FilesInterface $files,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function update(string $sourcePath, string $targetPath): bool
+    {
+        // Create the update script
+        $scriptPath = $this->createUpdateScript($sourcePath, $targetPath);
+
+        if ($scriptPath === null) {
+            return false;
+        }
+
+        // Run the script in the background
+        $command = \sprintf(
+            'start /b "" %s',
+            \escapeshellarg($scriptPath),
+        );
+
+        // Execute the command
+        $output = [];
+        $resultCode = 0;
+        \exec($command, $output, $resultCode);
+
+        return $resultCode === 0;
+    }
+
+    /**
+     * Create a temporary batch script that will perform the update.
+     *
+     * @return string|null Path to the created script, or null if creation failed
+     */
+    private function createUpdateScript(string $sourcePath, string $targetPath): ?string
+    {
+        $scriptPath = $this->files->tempFilename('.bat');
+
+        try {
+            // Convert paths to Windows-style
+            $sourcePath = \str_replace('/', '\\', $sourcePath);
+            $targetPath = \str_replace('/', '\\', $targetPath);
+            $targetDir = \str_replace('/', '\\', \dirname($targetPath));
+            $scriptPathWin = \str_replace('/', '\\', $scriptPath);
+
+            $scriptContent = <<<BATCH
+                @echo off
+                rem Wait for parent process to exit
+                timeout /t 1 /nobreak > nul
+                
+                rem Define paths
+                set SOURCE={$sourcePath}
+                set TARGET={$targetPath}
+                set TARGET_DIR={$targetDir}
+                
+                echo Starting update process for %TARGET%
+                
+                rem Create the target directory if it doesn't exist
+                if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
+                
+                rem Try to update the file with multiple attempts
+                set MAX_ATTEMPTS=10
+                set ATTEMPT=1
+                set SUCCESS=0
+                
+                :LOOP
+                if %ATTEMPT% gtr %MAX_ATTEMPTS% goto FAILED
+                if %SUCCESS% equ 1 goto SUCCESS
+                
+                echo Attempt %ATTEMPT%: Trying to update %TARGET%
+                
+                rem Try to copy the file
+                copy /Y "%SOURCE%" "%TARGET%" > nul 2>&1
+                if %ERRORLEVEL% equ 0 (
+                    set SUCCESS=1
+                    goto SUCCESS
+                ) else (
+                    echo Binary busy or permission denied, waiting 2 seconds...
+                    timeout /t 2 /nobreak > nul
+                    set /a ATTEMPT+=1
+                    goto LOOP
+                )
+                
+                :FAILED
+                echo Update failed after %MAX_ATTEMPTS% attempts.
+                goto CLEANUP
+                
+                :SUCCESS
+                echo Update successful!
+                
+                :CLEANUP
+                rem Clean up temporary files
+                del "%SOURCE%" > nul 2>&1
+                del "{$scriptPathWin}" > nul 2>&1
+                
+                if %SUCCESS% equ 0 exit /b 1
+                exit /b 0
+                BATCH;
+
+            $this->files->write($scriptPath, $scriptContent);
+            return $scriptPath;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Lib/BinaryUpdater/UpdaterFactory.php
+++ b/src/Lib/BinaryUpdater/UpdaterFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\BinaryUpdater;
+
+use Butschster\ContextGenerator\Lib\BinaryUpdater\Strategy\UnixUpdateStrategy;
+use Butschster\ContextGenerator\Lib\BinaryUpdater\Strategy\UpdateStrategyInterface;
+use Butschster\ContextGenerator\Lib\BinaryUpdater\Strategy\WindowsUpdateStrategy;
+use Psr\Log\LoggerInterface;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Factory for creating platform-specific update strategies.
+ */
+final readonly class UpdaterFactory
+{
+    /**
+     * @param FilesInterface $files File system service
+     */
+    public function __construct(
+        private FilesInterface $files,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Create an appropriate update strategy based on the current platform.
+     */
+    public function createStrategy(): UpdateStrategyInterface
+    {
+        // Create the appropriate strategy based on the operating system
+        return match (\PHP_OS_FAMILY) {
+            'Windows' => new WindowsUpdateStrategy($this->files, $this->logger),
+            default => new UnixUpdateStrategy($this->files, $this->logger),
+        };
+    }
+}

--- a/src/Lib/GithubClient/Architecture.php
+++ b/src/Lib/GithubClient/Architecture.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\GithubClient;
+
+enum Architecture: string
+{
+    case Amd64 = 'amd64';
+    case Arm64 = 'arm64';
+
+    public static function detect(): self
+    {
+        $arch = \php_uname('m');
+
+        return match (\strtolower($arch)) {
+            'x86_64', 'amd64' => self::Amd64,
+            'aarch64', 'arm64' => self::Arm64,
+            // Add more mappings as needed
+            default => throw new \RuntimeException('Unsupported architecture: ' . $arch),
+        };
+    }
+}

--- a/src/Lib/GithubClient/BinaryNameBuilder.php
+++ b/src/Lib/GithubClient/BinaryNameBuilder.php
@@ -31,13 +31,6 @@ final readonly class BinaryNameBuilder
             $extension = ($platform->isWindows() && $type === 'bin') ? $platform->extension() : '';
 
             return match ($type) {
-                'phar' => \sprintf(
-                    "%s-%s-%s-%s.phar",
-                    $baseName,
-                    $version,
-                    $platform->value,
-                    $architecture->value,
-                ),
                 'bin' => \sprintf(
                     "%s-%s-%s-%s%s",
                     $baseName,

--- a/src/Lib/GithubClient/BinaryNameBuilder.php
+++ b/src/Lib/GithubClient/BinaryNameBuilder.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\GithubClient;
+
+/**
+ * Builds platform-specific binary names based on current environment.
+ */
+final readonly class BinaryNameBuilder
+{
+    /**
+     * Builds a platform-specific binary filename.
+     *
+     * @param string $baseName The base name of the binary (e.g., 'ctx')
+     * @param string $version The version (e.g., '1.0.0')
+     * @param string $type The type of binary ('bin' or 'phar')
+     * @return string The constructed filename
+     * @throws \RuntimeException If platform or architecture detection fails
+     */
+    public function buildPlatformSpecificName(string $baseName, string $version, string $type): string
+    {
+        if ($type === 'phar') {
+            return $this->buildGenericName($baseName, $type);
+        }
+
+        try {
+            $platform = $this->detectPlatform();
+            $architecture = $this->detectArchitecture();
+
+            $extension = ($platform->isWindows() && $type === 'bin') ? $platform->extension() : '';
+
+            return match ($type) {
+                'phar' => \sprintf(
+                    "%s-%s-%s-%s.phar",
+                    $baseName,
+                    $version,
+                    $platform->value,
+                    $architecture->value,
+                ),
+                'bin' => \sprintf(
+                    "%s-%s-%s-%s%s",
+                    $baseName,
+                    $version,
+                    $platform->value,
+                    $architecture->value,
+                    $extension,
+                ),
+                default => throw new \InvalidArgumentException('Invalid type provided: ' . $type),
+            };
+        } catch (\Throwable $e) {
+            throw new \RuntimeException("Failed to build platform-specific binary name: {$e->getMessage()}", 0, $e);
+        }
+    }
+
+    /**
+     * Builds a generic (legacy) binary filename.
+     *
+     * @param string $baseName The base name of the binary (e.g., 'ctx')
+     * @param string $type The type of binary ('bin' or 'phar')
+     * @return string The constructed filename
+     */
+    public function buildGenericName(string $baseName, string $type): string
+    {
+        return match ($type) {
+            'phar' => "{$baseName}.phar",
+            'bin' => $baseName,
+            default => throw new \InvalidArgumentException('Invalid type provided: ' . $type),
+        };
+    }
+
+    /**
+     * Detects the current platform (linux, darwin, windows).
+     */
+    private function detectPlatform(): Platform
+    {
+        return Platform::detect();
+    }
+
+    /**
+     * Detects the current architecture (amd64, arm64).
+     */
+    private function detectArchitecture(): Architecture
+    {
+        return Architecture::detect();
+    }
+}

--- a/src/Lib/GithubClient/GithubClient.php
+++ b/src/Lib/GithubClient/GithubClient.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Lib\GithubClient;
 
+use Butschster\ContextGenerator\Lib\GithubClient\Model\GithubRepository;
+use Butschster\ContextGenerator\Lib\GithubClient\Model\Release;
 use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
 
 final class GithubClient implements GithubClientInterface
@@ -65,6 +67,15 @@ final class GithubClient implements GithubClientInterface
     public function setToken(?string $token): void
     {
         $this->token = $token;
+    }
+
+    public function getReleaseManager(GithubRepository $repository): ReleaseManager
+    {
+        return new ReleaseManager(
+            $this->httpClient,
+            $repository,
+            $this->token,
+        );
     }
 
     /**

--- a/src/Lib/GithubClient/GithubClient.php
+++ b/src/Lib/GithubClient/GithubClient.php
@@ -21,14 +21,13 @@ final class GithubClient implements GithubClientInterface
         private ?string $token = null,
     ) {}
 
-    public function getContents(string $owner, string $repo, string $path = '', string $branch = 'main'): array
+    public function getContents(GithubRepository $repository, string $path = ''): array
     {
         $url = \sprintf(
-            '/repos/%s/%s/contents/%s?ref=%s',
-            \urlencode($owner),
-            \urlencode($repo),
+            '/repos/%s/contents/%s?ref=%s',
+            $repository->repository,
             $path ? \urlencode($path) : '',
-            \urlencode($branch),
+            \urlencode($repository->branch),
         );
 
         $response = $this->sendRequest('GET', $url);
@@ -43,14 +42,13 @@ final class GithubClient implements GithubClientInterface
         return $response;
     }
 
-    public function getFileContent(string $owner, string $repo, string $path, string $branch = 'main'): string
+    public function getFileContent(GithubRepository $repository, string $path): string
     {
         $url = \sprintf(
-            '/repos/%s/%s/contents/%s?ref=%s',
-            \urlencode($owner),
-            \urlencode($repo),
+            '/repos/%s/contents/%s?ref=%s',
+            $repository->repository,
             \urlencode($path),
-            \urlencode($branch),
+            \urlencode($repository->branch),
         );
 
         $response = $this->sendRequest('GET', $url);

--- a/src/Lib/GithubClient/GithubClient.php
+++ b/src/Lib/GithubClient/GithubClient.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Lib\GithubClient;
 
 use Butschster\ContextGenerator\Lib\GithubClient\Model\GithubRepository;
-use Butschster\ContextGenerator\Lib\GithubClient\Model\Release;
 use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
 
 final class GithubClient implements GithubClientInterface

--- a/src/Lib/GithubClient/GithubClientInterface.php
+++ b/src/Lib/GithubClient/GithubClientInterface.php
@@ -10,25 +10,14 @@ interface GithubClientInterface
 {
     /**
      * Get repository contents from the GitHub API
-     *
-     * @param string $owner Repository owner
-     * @param string $repo Repository name
-     * @param string $path Path within the repository
-     * @param string $branch Repository branch or tag
-     * @return array<string, mixed> Repository contents
      */
-    public function getContents(string $owner, string $repo, string $path = '', string $branch = 'main'): array;
+    public function getContents(GithubRepository $repository, string $path = ''): array;
 
     /**
      * Get file content from GitHub API
-     *
-     * @param string $owner Repository owner
-     * @param string $repo Repository name
-     * @param string $path File path within the repository
-     * @param string $branch Repository branch or tag
      * @return string File content
      */
-    public function getFileContent(string $owner, string $repo, string $path, string $branch = 'main'): string;
+    public function getFileContent(GithubRepository $repository, string $path): string;
 
     /**
      * Set the GitHub API token

--- a/src/Lib/GithubClient/GithubClientInterface.php
+++ b/src/Lib/GithubClient/GithubClientInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Lib\GithubClient;
 
+use Butschster\ContextGenerator\Lib\GithubClient\Model\GithubRepository;
+
 interface GithubClientInterface
 {
     /**
@@ -13,6 +15,7 @@ interface GithubClientInterface
      * @param string $repo Repository name
      * @param string $path Path within the repository
      * @param string $branch Repository branch or tag
+     * @return array<string, mixed> Repository contents
      */
     public function getContents(string $owner, string $repo, string $path = '', string $branch = 'main'): array;
 
@@ -33,4 +36,12 @@ interface GithubClientInterface
      * @param string|null $token GitHub API token
      */
     public function setToken(?string $token): void;
+
+    /**
+     * Get the release manager for a repository
+     *
+     * @param GithubRepository $repository Repository
+     * @return ReleaseManager Release manager
+     */
+    public function getReleaseManager(GithubRepository $repository): ReleaseManager;
 }

--- a/src/Lib/GithubClient/Model/GithubRepository.php
+++ b/src/Lib/GithubClient/Model/GithubRepository.php
@@ -7,40 +7,18 @@ namespace Butschster\ContextGenerator\Lib\GithubClient\Model;
 final readonly class GithubRepository
 {
     /**
-     * @param string $owner Repository owner
-     * @param string $name Repository name
+     * @param string $repository Repository name in the format "owner/repo"
      * @param string $branch Repository branch or tag
      */
     public function __construct(
-        public string $owner,
-        public string $name,
+        public string $repository,
         public string $branch = 'main',
-    ) {}
-
-    /**
-     * Create a repository from a string in the format "owner/repo"
-     *
-     * @param string $repository Repository string in format "owner/repo"
-     * @param string $branch Repository branch or tag
-     * @throws \InvalidArgumentException If repository string is invalid
-     */
-    public static function fromString(string $repository, string $branch = 'main'): self
-    {
-        if (!\preg_match('/^([^\/]+)\/([^\/]+)$/', $repository, $matches)) {
+    ) {
+        if (!\preg_match('/^([^\/]+)\/([^\/]+)$/', $repository)) {
             throw new \InvalidArgumentException(
                 "Invalid repository format: $repository. Expected format: owner/repo",
             );
         }
-
-        return new self($matches[1], $matches[2], $branch);
-    }
-
-    /**
-     * Get the full repository name in the format "owner/repo"
-     */
-    public function getFullName(): string
-    {
-        return "{$this->owner}/{$this->name}";
     }
 
     /**
@@ -48,6 +26,6 @@ final readonly class GithubRepository
      */
     public function getUrl(): string
     {
-        return "https://github.com/{$this->owner}/{$this->name}";
+        return \sprintf("https://github.com/%s", $this->repository);
     }
 }

--- a/src/Lib/GithubClient/Model/Release.php
+++ b/src/Lib/GithubClient/Model/Release.php
@@ -25,6 +25,33 @@ final readonly class Release
     ) {}
 
     /**
+     * Create a Release instance from GitHub API response data.
+     *
+     * @param array<string, mixed> $data GitHub API release data
+     */
+    public static function fromApiResponse(array $data): self
+    {
+        $assets = [];
+
+        // Process assets to create a map of filename => download URL
+        if (isset($data['assets']) && \is_array($data['assets'])) {
+            foreach ($data['assets'] as $asset) {
+                if (isset($asset['name'], $asset['browser_download_url'])) {
+                    $assets[(string) $asset['name']] = (string) $asset['browser_download_url'];
+                }
+            }
+        }
+
+        return new self(
+            tagName: (string) ($data['tag_name'] ?? ''),
+            name: (string) ($data['name'] ?? ''),
+            body: (string) ($data['body'] ?? ''),
+            htmlUrl: (string) ($data['html_url'] ?? ''),
+            assets: $assets,
+        );
+    }
+
+    /**
      * Get the version number without the "v" prefix.
      */
     public function getVersion(): string
@@ -50,32 +77,5 @@ final readonly class Release
     public function getAssetUrl(string $fileName): ?string
     {
         return $this->assets[$fileName] ?? null;
-    }
-
-    /**
-     * Create a Release instance from GitHub API response data.
-     *
-     * @param array<string, mixed> $data GitHub API release data
-     */
-    public static function fromApiResponse(array $data): self
-    {
-        $assets = [];
-
-        // Process assets to create a map of filename => download URL
-        if (isset($data['assets']) && \is_array($data['assets'])) {
-            foreach ($data['assets'] as $asset) {
-                if (isset($asset['name'], $asset['browser_download_url'])) {
-                    $assets[(string) $asset['name']] = (string) $asset['browser_download_url'];
-                }
-            }
-        }
-
-        return new self(
-            tagName: (string) ($data['tag_name'] ?? ''),
-            name: (string) ($data['name'] ?? ''),
-            body: (string) ($data['body'] ?? ''),
-            htmlUrl: (string) ($data['html_url'] ?? ''),
-            assets: $assets,
-        );
     }
 }

--- a/src/Lib/GithubClient/Model/Release.php
+++ b/src/Lib/GithubClient/Model/Release.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\GithubClient\Model;
+
+/**
+ * Represents a GitHub release.
+ */
+final readonly class Release
+{
+    /**
+     * @param string $tagName Release tag name (e.g. "v1.0.0" or "1.0.0")
+     * @param string $name Release name
+     * @param string $body Release description
+     * @param string $htmlUrl HTML URL to view the release
+     * @param array<string, string> $assets Release assets (filename => download URL)
+     */
+    public function __construct(
+        public string $tagName,
+        public string $name,
+        public string $body,
+        public string $htmlUrl,
+        public array $assets = [],
+    ) {}
+
+    /**
+     * Get the version number without the "v" prefix.
+     */
+    public function getVersion(): string
+    {
+        return \ltrim($this->tagName, 'v');
+    }
+
+    /**
+     * Check if this release is newer than the provided version.
+     */
+    public function isNewerThan(string $currentVersion): bool
+    {
+        // Clean up versions for comparison
+        $currentVersion = \ltrim($currentVersion, 'v');
+        $releaseVersion = $this->getVersion();
+
+        return \version_compare($currentVersion, $releaseVersion, '<');
+    }
+
+    /**
+     * Get the download URL for a specific asset.
+     */
+    public function getAssetUrl(string $fileName): ?string
+    {
+        return $this->assets[$fileName] ?? null;
+    }
+
+    /**
+     * Create a Release instance from GitHub API response data.
+     *
+     * @param array<string, mixed> $data GitHub API release data
+     */
+    public static function fromApiResponse(array $data): self
+    {
+        $assets = [];
+
+        // Process assets to create a map of filename => download URL
+        if (isset($data['assets']) && \is_array($data['assets'])) {
+            foreach ($data['assets'] as $asset) {
+                if (isset($asset['name'], $asset['browser_download_url'])) {
+                    $assets[(string) $asset['name']] = (string) $asset['browser_download_url'];
+                }
+            }
+        }
+
+        return new self(
+            tagName: (string) ($data['tag_name'] ?? ''),
+            name: (string) ($data['name'] ?? ''),
+            body: (string) ($data['body'] ?? ''),
+            htmlUrl: (string) ($data['html_url'] ?? ''),
+            assets: $assets,
+        );
+    }
+}

--- a/src/Lib/GithubClient/Platform.php
+++ b/src/Lib/GithubClient/Platform.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\GithubClient;
+
+enum Platform: string
+{
+    case Linux = 'linux';
+    case Macos = 'darwin';
+    case Windows = 'windows';
+
+    public static function detect(): self
+    {
+        return match (PHP_OS_FAMILY) {
+            'Linux' => self::Linux,
+            'Darwin' => self::Macos,
+            'Windows' => self::Windows,
+            default => throw new \RuntimeException('Unsupported platform: ' . PHP_OS_FAMILY),
+        };
+    }
+
+    public function isWindows(): bool
+    {
+        return $this === self::Windows;
+    }
+
+    public function extension(): string
+    {
+        return $this->isWindows() ? '.exe' : '';
+    }
+}

--- a/src/Lib/GithubClient/ReleaseManager.php
+++ b/src/Lib/GithubClient/ReleaseManager.php
@@ -12,7 +12,7 @@ use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
 /**
  * Manages GitHub releases for a repository.
  */
-final class ReleaseManager
+final readonly class ReleaseManager
 {
     /**
      * @param HttpClientInterface $httpClient HTTP client for API requests
@@ -20,8 +20,8 @@ final class ReleaseManager
      * @param string|null $token GitHub API token
      */
     public function __construct(
-        private readonly HttpClientInterface $httpClient,
-        private readonly GithubRepository $repository,
+        private HttpClientInterface $httpClient,
+        private GithubRepository $repository,
         private ?string $token = null,
     ) {}
 
@@ -36,8 +36,6 @@ final class ReleaseManager
             'https://api.github.com/repos/%s/releases/latest',
             $this->repository->repository,
         );
-
-        trap($url);
 
         $response = $this->httpClient->get(
             $url,

--- a/src/Lib/GithubClient/ReleaseManager.php
+++ b/src/Lib/GithubClient/ReleaseManager.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\GithubClient;
+
+use Butschster\ContextGenerator\Lib\GithubClient\Model\GithubRepository;
+use Butschster\ContextGenerator\Lib\GithubClient\Model\Release;
+use Butschster\ContextGenerator\Lib\HttpClient\Exception\HttpException;
+use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
+
+/**
+ * Manages GitHub releases for a repository.
+ */
+final class ReleaseManager
+{
+    /**
+     * @param HttpClientInterface $httpClient HTTP client for API requests
+     * @param GithubRepository $repository Target repository
+     * @param string|null $token GitHub API token
+     */
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly GithubRepository $repository,
+        private ?string $token = null,
+    ) {}
+
+    /**
+     * Get the latest release from GitHub.
+     *
+     * @throws \RuntimeException If the request fails
+     */
+    public function getLatestRelease(): Release
+    {
+        $url = \sprintf(
+            'https://api.github.com/repos/%s/releases/latest',
+            $this->repository->repository,
+        );
+
+        trap($url);
+
+        $response = $this->httpClient->get(
+            $url,
+            $this->getHeaders(),
+        );
+
+        if (!$response->isSuccess()) {
+            throw new \RuntimeException(
+                "Failed to fetch latest release. Server returned status code {$response->getStatusCode()}",
+            );
+        }
+
+        try {
+            $data = $response->getJson();
+            return Release::fromApiResponse($data);
+        } catch (HttpException $e) {
+            throw new \RuntimeException("Failed to parse GitHub response: {$e->getMessage()}", 0, $e);
+        }
+    }
+
+    /**
+     * Download a release asset to a local file.
+     *
+     * @param string $assetUrl URL of the asset to download
+     * @param string $destinationPath Local path to save the file
+     * @throws \RuntimeException If the download fails
+     */
+    public function downloadAsset(string $assetUrl, string $destinationPath): void
+    {
+        $response = $this->httpClient->getWithRedirects(
+            $assetUrl,
+            $this->getHeaders(),
+        );
+
+        if (!$response->isSuccess()) {
+            throw new \RuntimeException(
+                "Failed to download asset. Server returned status code {$response->getStatusCode()}",
+            );
+        }
+
+        // Write the file
+        if (!\file_put_contents($destinationPath, $response->getBody())) {
+            throw new \RuntimeException("Failed to write file: {$destinationPath}");
+        }
+
+        // Make the file executable if it's not a Windows system
+        if (\PHP_OS_FAMILY !== 'Windows') {
+            if (!\chmod($destinationPath, 0755)) {
+                throw new \RuntimeException("Failed to set executable permissions on the file: {$destinationPath}");
+            }
+        }
+    }
+
+    /**
+     * Generate standard headers for GitHub API requests.
+     *
+     * @return array<string, string> Headers
+     */
+    private function getHeaders(): array
+    {
+        $headers = [
+            'Accept' => 'application/vnd.github.v3+json',
+            'User-Agent' => 'ContextGenerator',
+        ];
+
+        if ($this->token) {
+            $headers['Authorization'] = 'token ' . $this->token;
+        }
+
+        return $headers;
+    }
+}

--- a/src/Lib/PathFilter/FileHelper.php
+++ b/src/Lib/PathFilter/FileHelper.php
@@ -39,6 +39,7 @@ final readonly class FileHelper
         $inCurlies = 0;
         $regex = '';
         $sizeGlob = \strlen($glob);
+        /** @psalm-suppress InvalidOperand */
         for ($i = 0; $i < $sizeGlob; ++$i) {
             /** @psalm-suppress InvalidArrayOffset */
             $car = $glob[$i];
@@ -48,10 +49,16 @@ final readonly class FileHelper
 
             $firstByte = $car === '/';
 
-            /** @psalm-suppress InvalidArrayOffset */
+            /**
+             * @psalm-suppress InvalidArrayOffset
+             * @psalm-suppress InvalidOperand
+             */
             if ($firstByte && $strictWildcardSlash && isset($glob[$i + 2]) && '**' === $glob[$i + 1] . $glob[$i + 2] && (!isset($glob[$i + 3]) || $glob[$i + 3] === '/')) {
                 $car = '[^/]++/';
-                /** @psalm-suppress InvalidArrayOffset */
+                /**
+                 * @psalm-suppress InvalidArrayOffset
+                 * @psalm-suppress InvalidOperand
+                 */
                 if (!isset($glob[$i + 3])) {
                     $car .= '?';
                 }

--- a/src/Lib/TreeBuilder/TreeRenderer/AsciiTreeRenderer.php
+++ b/src/Lib/TreeBuilder/TreeRenderer/AsciiTreeRenderer.php
@@ -198,9 +198,15 @@ final readonly class AsciiTreeRenderer implements TreeRendererInterface
         $units = ['B', 'KB', 'MB', 'GB', 'TB'];
 
         $bytes = \max($bytes, 0);
+        /**
+         * @psalm-suppress InvalidOperand
+         */
         $pow = \floor(($bytes ? \log($bytes) : 0) / \log(1024));
         $pow = \min($pow, \count($units) - 1);
 
+        /**
+         * @psalm-suppress InvalidOperand
+         */
         $bytes /= (1 << (10 * $pow));
 
         return \sprintf('%.1f %s', $bytes, $units[$pow]);

--- a/src/Modifier/PhpDocs/AstDocTransformer.php
+++ b/src/Modifier/PhpDocs/AstDocTransformer.php
@@ -476,7 +476,7 @@ final class AstDocTransformer implements SourceModifierInterface
 
         $params = [];
         foreach ($method->getParameters() as $param) {
-            $paramType = $param->getType() ? $param->getType() . ' ' : '';
+            $paramType = $param->getType() ? (string) $param->getType() . ' ' : '';
             $paramName = '$' . $param->getName();
 
             $paramStr = $paramType . $paramName;
@@ -490,7 +490,7 @@ final class AstDocTransformer implements SourceModifierInterface
         }
 
         $paramsStr = \implode(', ', $params);
-        $returnType = $method->getReturnType() ? ': ' . $method->getReturnType() : '';
+        $returnType = $method->getReturnType() ? ': ' . (string) $method->getReturnType() : '';
 
         return "{$visibility}{$staticFlag}{$abstractFlag}{$finalFlag}function {$methodName}({$paramsStr}){$returnType}";
     }

--- a/src/Source/Github/GithubFinder.php
+++ b/src/Source/Github/GithubFinder.php
@@ -205,12 +205,7 @@ final class GithubFinder implements FinderInterface
      */
     private function fetchDirectoryContents(GithubRepository $repository, string $path = ''): array
     {
-        return $this->githubClient->getContents(
-            $repository->owner,
-            $repository->name,
-            $path,
-            $repository->branch,
-        );
+        return $this->githubClient->getContents($repository, $path);
     }
 
     /**
@@ -218,11 +213,6 @@ final class GithubFinder implements FinderInterface
      */
     private function fetchFileContent(GithubRepository $repository, string $path): string
     {
-        return $this->githubClient->getFileContent(
-            $repository->owner,
-            $repository->name,
-            $path,
-            $repository->branch,
-        );
+        return $this->githubClient->getFileContent($repository, $path);
     }
 }

--- a/src/Source/Github/GithubFinder.php
+++ b/src/Source/Github/GithubFinder.php
@@ -54,7 +54,7 @@ final class GithubFinder implements FinderInterface
         }
 
         // Parse repository from string
-        $repository = GithubRepository::fromString($source->repository, $source->branch);
+        $repository = new GithubRepository($source->repository, $source->branch);
 
         // Initialize path filters based on source configuration
         $this->initializePathFilters($source);

--- a/src/Source/Github/GithubSourceFetcher.php
+++ b/src/Source/Github/GithubSourceFetcher.php
@@ -57,7 +57,7 @@ final readonly class GithubSourceFetcher implements SourceFetcherInterface
             'repository' => $source->repository,
             'branch' => $source->branch,
         ]);
-        $repository = GithubRepository::fromString($source->repository, $source->branch);
+        $repository = new GithubRepository($source->repository, $source->branch);
 
         // Create builder
         $this->logger?->debug('Creating content builder');


### PR DESCRIPTION
This PR implements platform and architecture detection for the `self-update` command, allowing it to download the appropriate binary based on the user's system.

### Changes

- Created a new `BinaryNameBuilder` class to generate platform-specific binary names (e.g., `ctx-1.22.0-darwin-arm64`)

### How It Works

1. The system detects the current platform (`linux`, `darwin`, `windows`) and architecture (`amd64`, `arm64`)
2. It first attempts to download the platform-specific binary (e.g., `ctx-1.22.0-linux-amd64`)
3. If that fails, it automatically falls back to the generic binary format (e.g., `ctx` or `ctx.phar`)
4. All existing functionality is preserved for environments where detection isn't possible

---

## Fix: Self-update command fails with "Text file busy" error

When executing the `self-update` command, the application was trying to overwrite the currently running PHAR file, which resulted in the following error:

```
Warning: file_put_contents(/usr/local/bin/ctx): Failed to open stream: Text file busy in phar:///usr/local/bin/ctx/src/Lib/Files.php on line 41
```

I've implemented a robust binary updating system that handles the "Text file busy" scenario:

1. Created a `BinaryUpdater` class that:
   - First attempts a direct update (which works if the file isn't busy)
   - Falls back to platform-specific update strategies if direct update fails

2. Implemented platform-specific update strategies:
   - `UnixUpdateStrategy` - Creates a bash script that runs after the process exits
   - `WindowsUpdateStrategy` - Creates a batch script for Windows environments

3. Updated `SelfUpdateCommand` to use the new `BinaryUpdater` system

The update process now:
1. Downloads the new version to a temporary file
2. Tries to directly update the binary (may work in some cases)
3. If that fails, creates and executes a background script that:
   - Waits for the parent process to exit
   - Tries multiple times to replace the binary
   - Provides appropriate feedback to the user
   - Cleans up temporary files

This approach ensures that the update completes successfully even when the binary is currently in use, and it works correctly across different platforms.