### PR TITLE
Add support for custom variables in configuration files

### DIFF
--- a/json-schema.json
+++ b/json-schema.json
@@ -28,6 +28,31 @@
         "$ref": "#/definitions/prompt"
       }
     },
+    "variables": {
+      "type": "object",
+      "description": "Custom variables to use throughout the configuration",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "examples": [
+        {
+          "version": "1.0.0",
+          "project_name": "My Project",
+          "environment": "development",
+          "api_token": "xyz-123-abc"
+        }
+      ]
+    },
     "import": {
       "type": "array",
       "description": "List of external configuration files to import",

--- a/src/Application/Bootloader/ConfigLoaderBootloader.php
+++ b/src/Application/Bootloader/ConfigLoaderBootloader.php
@@ -20,6 +20,7 @@ use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
 use Butschster\ContextGenerator\Document\DocumentsParserPlugin;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Modifier\Alias\AliasesRegistry;
 use Butschster\ContextGenerator\Modifier\Alias\ModifierAliasesParserPlugin;
 use Butschster\ContextGenerator\Modifier\Alias\ModifierResolver;
@@ -100,11 +101,13 @@ final class ConfigLoaderBootloader extends Bootloader
                 SourceModifierRegistry $registry,
                 ContentBuilderFactory $builderFactory,
                 HasPrefixLoggerInterface $logger,
+                VariableResolver $variables,
             ) => new DocumentCompiler(
                 files: $files,
                 parser: $parser,
                 basePath: (string) $dirs->getOutputPath(),
                 modifierRegistry: $registry,
+                variables: $variables,
                 builderFactory: $builderFactory,
                 logger: $logger->withPrefix('document-compiler'),
             ),

--- a/src/Application/Bootloader/VariableBootloader.php
+++ b/src/Application/Bootloader/VariableBootloader.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Application\Bootloader;
 
 use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
+use Butschster\ContextGenerator\Config\Parser\VariablesParserPlugin;
 use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\Lib\Variable\Provider\CompositeVariableProvider;
+use Butschster\ContextGenerator\Lib\Variable\Provider\ConfigVariableProvider;
 use Butschster\ContextGenerator\Lib\Variable\Provider\DotEnvVariableProvider;
 use Butschster\ContextGenerator\Lib\Variable\Provider\PredefinedVariableProvider;
 use Butschster\ContextGenerator\Lib\Variable\VariableReplacementProcessor;
@@ -20,9 +22,22 @@ final class VariableBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
+            // Singleton provider for variables from config
+            ConfigVariableProvider::class => static fn() => new ConfigVariableProvider(),
+
+            // Parser plugin for extracting variables from config
+            VariablesParserPlugin::class => static fn(
+                ConfigVariableProvider $variableProvider,
+                HasPrefixLoggerInterface $logger,
+            ) => new VariablesParserPlugin(
+                variableProvider: $variableProvider,
+                logger: $logger->withPrefix('variables-parser'),
+            ),
+
             VariableResolver::class => static function (
                 DirectoriesInterface $dirs,
                 HasPrefixLoggerInterface $logger,
+                ConfigVariableProvider $configVariableProvider,
             ) {
                 $envFilePath = null;
                 $envFileName = null;
@@ -35,17 +50,30 @@ final class VariableBootloader extends Bootloader
                 return new VariableResolver(
                     processor: new VariableReplacementProcessor(
                         provider: new CompositeVariableProvider(
-                            envProvider: new DotEnvVariableProvider(
+                            $configVariableProvider,
+
+                            // Environment variables have middle priority
+                            new DotEnvVariableProvider(
                                 repository: RepositoryBuilder::createWithDefaultAdapters()->make(),
                                 rootPath: $envFilePath,
                                 envFileName: $envFileName,
                             ),
-                            predefinedProvider: new PredefinedVariableProvider(),
+
+                            // Predefined system variables have lowest priority
+                            new PredefinedVariableProvider(),
                         ),
                         logger: $logger->withPrefix('variable-resolver'),
                     ),
                 );
             },
         ];
+    }
+
+    public function boot(
+        ConfigLoaderBootloader $configLoaderBootloader,
+        VariablesParserPlugin $variablesParserPlugin,
+    ): void {
+        // Register the variables parser plugin with the config loader
+        $configLoaderBootloader->registerParserPlugin($variablesParserPlugin);
     }
 }

--- a/src/Config/Import/ImportResolver.php
+++ b/src/Config/Import/ImportResolver.php
@@ -255,6 +255,8 @@ final readonly class ImportResolver
 
     /**
      * Merge multiple configurations
+     *
+     * todo: move to a parsers??
      */
     private function mergeConfigurations(array $configs): array
     {

--- a/src/Config/Parser/VariablesParserPlugin.php
+++ b/src/Config/Parser/VariablesParserPlugin.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Parser;
+
+use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
+use Butschster\ContextGenerator\Lib\Variable\Provider\ConfigVariableProvider;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Plugin for parsing the 'variables' section in configuration files
+ */
+final readonly class VariablesParserPlugin implements ConfigParserPluginInterface
+{
+    public function __construct(
+        private ConfigVariableProvider $variableProvider,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function getConfigKey(): string
+    {
+        return 'variables';
+    }
+
+    public function supports(array $config): bool
+    {
+        return isset($config['variables']) && \is_array($config['variables']);
+    }
+
+    public function parse(array $config, string $rootPath): ?RegistryInterface
+    {
+        if (!$this->supports($config)) {
+            return null;
+        }
+
+        $variables = $config['variables'];
+
+        $this->logger?->debug('Parsing variables from config', [
+            'count' => \count($variables),
+            'keys' => \array_keys($variables),
+        ]);
+
+        // Update the variables in the provider
+        $this->variableProvider->setVariables($variables);
+
+        return null;
+    }
+
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // We don't need to modify the config, just return it as is
+        return $config;
+    }
+}

--- a/src/Config/Registry/ConfigRegistry.php
+++ b/src/Config/Registry/ConfigRegistry.php
@@ -39,11 +39,11 @@ final class ConfigRegistry implements \JsonSerializable
      *
      * @template T of RegistryInterface
      * @param class-string<T> $className Optional class name to validate the registry type
-     * @return RegistryInterface The requested registry
+     * @return T
      *
      * @throws \InvalidArgumentException If the registry does not exist or is not of the expected type
      */
-    public function get(string $type, string $className = RegistryInterface::class): RegistryInterface
+    public function get(string $type, string $className): RegistryInterface
     {
         if (!$this->has($type)) {
             throw new \InvalidArgumentException(\sprintf('Registry of type "%s" does not exist', $type));

--- a/src/Lib/Variable/Provider/ConfigVariableProvider.php
+++ b/src/Lib/Variable/Provider/ConfigVariableProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Variable\Provider;
+
+use Spiral\Core\Attribute\Singleton;
+
+/**
+ * Provider for custom variables defined in the configuration file
+ */
+#[Singleton]
+final class ConfigVariableProvider implements VariableProviderInterface
+{
+    /**
+     * @var array<string, string> Custom variables from config
+     */
+    private array $variables = [];
+
+    public function __construct(array $variables = [])
+    {
+        $this->setVariables($variables);
+    }
+
+    /**
+     * Set variables from config
+     *
+     * @param array<string, mixed> $variables Variables from config
+     */
+    public function setVariables(array $variables): self
+    {
+        $this->variables = [];
+
+        // Convert all values to strings
+        foreach ($variables as $key => $value) {
+            // Skip non-scalar values
+            if (!\is_scalar($value)) {
+                continue;
+            }
+
+            $this->variables[(string) $key] = (string) $value;
+        }
+
+        return $this;
+    }
+
+    public function has(string $name): bool
+    {
+        return \array_key_exists($name, $this->variables);
+    }
+
+    public function get(string $name): ?string
+    {
+        return $this->variables[$name] ?? null;
+    }
+
+    /**
+     * Get all variables
+     *
+     * @return array<string, string>
+     */
+    public function getAll(): array
+    {
+        return $this->variables;
+    }
+}

--- a/src/Lib/context.yaml
+++ b/src/Lib/context.yaml
@@ -23,6 +23,14 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
+  - description: Binary Updater
+    outputPath: utilities/binary-updater.md
+    sources:
+      - type: file
+        sourcePaths: ./BinaryUpdater
+        filePattern: '*.php'
+        showTreeView: true
+
   - description: GitHub Client
     outputPath: utilities/github-client.md
     sources:

--- a/tests/src/Document/Compiler/DocumentCompilerTest.php
+++ b/tests/src/Document/Compiler/DocumentCompilerTest.php
@@ -8,6 +8,7 @@ use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
 use Butschster\ContextGenerator\Document\Compiler\Error\SourceError;
 use Butschster\ContextGenerator\Document\Document;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Modifier\SourceModifierRegistry;
 use Butschster\ContextGenerator\Source\SourceInterface;
 use Butschster\ContextGenerator\SourceParserInterface;
@@ -300,6 +301,7 @@ final class DocumentCompilerTest extends TestCase
             parser: $this->parser,
             basePath: '/base/path',
             modifierRegistry: $this->modifierRegistry,
+            variables: new VariableResolver(),
             builderFactory: $this->builderFactory,
             logger: $this->logger,
         );


### PR DESCRIPTION
This PR adds support for defining custom variables directly in configuration files that can be referenced throughout the context definitions.

> Read more about variables [here](https://docs.ctxgithub.com/variables.html)

### Changes
- Added `ConfigVariableProvider` to store and manage custom variables
- Created `VariablesParserPlugin` to extract variables from configuration files
- Added `VariablesBootloader` to register the plugin with proper dependencies and integrate the custom variables provider

### Example
```yaml
variables:
  version: 1.0.0
  environment: development
  project_name: Context Generator

documents:
  - description: 'Project documentation'
    outputPath: docs/{{environment}}/{{project_name}}-{{version}}.md
    sources:
      - type: text
        content: |
          # {{project_name}} v{{version}}
          Environment: {{environment}}
```

### Schema update
Updated the JSON schema to include the new `variables` section.

Closes #143