### PR TITLE
Enhanced Logger Injection with PHP Attributes

### DIFF
--- a/src/Application/Bootloader/ComposerClientBootloader.php
+++ b/src/Application/Bootloader/ComposerClientBootloader.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Application\Bootloader;
 
+use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
 use Butschster\ContextGenerator\Lib\ComposerClient\ComposerClientInterface;
 use Butschster\ContextGenerator\Lib\ComposerClient\FileSystemComposerClient;
+use Butschster\ContextGenerator\Source\Composer\Provider\ComposerProviderInterface;
+use Butschster\ContextGenerator\Source\Composer\Provider\CompositeComposerProvider;
+use Butschster\ContextGenerator\Source\Composer\Provider\LocalComposerProvider;
 use Spiral\Boot\Bootloader\Bootloader;
 
 final class ComposerClientBootloader extends Bootloader
@@ -14,6 +18,14 @@ final class ComposerClientBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
+            ComposerProviderInterface::class => static fn(
+                HasPrefixLoggerInterface $logger,
+                LocalComposerProvider $localProvider,
+            ) => new CompositeComposerProvider(
+                logger: $logger->withPrefix('composer-provider'),
+                localProvider: $localProvider,
+            ),
+
             ComposerClientInterface::class => FileSystemComposerClient::class,
         ];
     }

--- a/src/Application/Bootloader/HttpClientBootloader.php
+++ b/src/Application/Bootloader/HttpClientBootloader.php
@@ -16,7 +16,10 @@ final class HttpClientBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
-            HttpClientInterface::class => static fn(Client $httpClient, HttpFactory $httpMessageFactory) => HttpClientFactory::create(
+            HttpClientInterface::class => static fn(
+                Client $httpClient,
+                HttpFactory $httpMessageFactory,
+            ) => HttpClientFactory::create(
                 $httpClient,
                 $httpMessageFactory,
             ),

--- a/src/Application/Bootloader/LoggerBootloader.php
+++ b/src/Application/Bootloader/LoggerBootloader.php
@@ -5,25 +5,67 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Application\Bootloader;
 
 use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Application\Logger\NullLogger;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\BinderInterface;
 use Spiral\Core\Config\Proxy;
+use Spiral\Core\Container\InjectorInterface;
 
-final class LoggerBootloader extends Bootloader
+/**
+ * @implements InjectorInterface<LoggerInterface>
+ */
+final class LoggerBootloader extends Bootloader implements InjectorInterface
 {
+    public function __construct(
+        private readonly ContainerInterface $container,
+    ) {}
+
     #[\Override]
     public function defineSingletons(): array
     {
         return [
-            LoggerInterface::class => new Proxy(
-                interface: LoggerInterface::class,
-                fallbackFactory: static fn(): LoggerInterface => new NullLogger(),
-            ),
             HasPrefixLoggerInterface::class => new Proxy(
                 interface: HasPrefixLoggerInterface::class,
-                fallbackFactory: static fn(): LoggerInterface => new NullLogger(),
+                fallbackFactory: static fn(): HasPrefixLoggerInterface => new NullLogger(),
             ),
         ];
+    }
+
+    public function boot(BinderInterface $binder): void
+    {
+        // Register injectable class
+        $binder->bindInjector(LoggerInterface::class, self::class);
+    }
+
+    public function createInjection(\ReflectionClass $class, mixed $context = null): LoggerInterface
+    {
+        $logger = $this->container->get(HasPrefixLoggerInterface::class);
+
+        $prefix = null;
+        if ($context instanceof \ReflectionParameter) {
+            $prefix = $this->findAttribute($context)?->prefix ?? $context->getDeclaringClass()->getShortName();
+        }
+
+        if (!$prefix) {
+            return $logger;
+        }
+
+        return $logger->withPrefix($prefix);
+    }
+
+    private function findAttribute(\ReflectionParameter $parameter): ?LoggerPrefix
+    {
+        foreach ($parameter->getAttributes(LoggerPrefix::class) as $attribute) {
+            return $attribute->newInstance();
+        }
+
+        foreach ($parameter->getDeclaringClass()->getAttributes(LoggerPrefix::class) as $attribute) {
+            return $attribute->newInstance();
+        }
+
+        return null;
     }
 }

--- a/src/Application/Logger/LoggerPrefix.php
+++ b/src/Application/Logger/LoggerPrefix.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Application\Logger;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS)]
+final readonly class LoggerPrefix
+{
+    public function __construct(
+        public string $prefix,
+    ) {}
+}

--- a/src/Config/ConfigurationProvider.php
+++ b/src/Config/ConfigurationProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Config;
 
 use Butschster\ContextGenerator\Application\FSPath;
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderFactoryInterface;
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
@@ -19,6 +20,7 @@ final readonly class ConfigurationProvider
     public function __construct(
         private ConfigLoaderFactoryInterface $loaderFactory,
         private DirectoriesInterface $dirs,
+        #[LoggerPrefix(prefix: 'config-provider')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Config/Import/ImportParserPlugin.php
+++ b/src/Config/Import/ImportParserPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Import;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Parser\ConfigParserPluginInterface;
 use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
 use Psr\Log\LoggerInterface;
@@ -15,6 +16,7 @@ final readonly class ImportParserPlugin implements ConfigParserPluginInterface
 {
     public function __construct(
         private ImportResolver $importResolver,
+        #[LoggerPrefix(prefix: 'import-parser')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Config/Import/ImportResolver.php
+++ b/src/Config/Import/ImportResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Import;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
 use Butschster\ContextGenerator\Config\Import\PathPrefixer\DocumentOutputPathPrefixer;
 use Butschster\ContextGenerator\Config\Import\PathPrefixer\SourcePathPrefixer;
@@ -22,22 +23,17 @@ use Spiral\Files\FilesInterface;
  */
 final readonly class ImportResolver
 {
-    private WildcardPathFinder $pathFinder;
-    private DocumentOutputPathPrefixer $documentPrefixer;
-    private SourcePathPrefixer $sourcePrefixer;
-    private SourceConfigFactory $sourceConfigFactory;
-
     public function __construct(
         private DirectoriesInterface $dirs,
         FilesInterface $files,
         private ImportSourceProvider $sourceProvider,
+        private WildcardPathFinder $pathFinder,
+        private DocumentOutputPathPrefixer $documentPrefixer = new DocumentOutputPathPrefixer(),
+        private SourcePathPrefixer $sourcePrefixer = new SourcePathPrefixer(),
+        private SourceConfigFactory $sourceConfigFactory = new SourceConfigFactory(),
+        #[LoggerPrefix(prefix: 'import-resolver')]
         private ?LoggerInterface $logger = null,
-    ) {
-        $this->pathFinder = new WildcardPathFinder($files, $logger);
-        $this->documentPrefixer = new DocumentOutputPathPrefixer();
-        $this->sourcePrefixer = new SourcePathPrefixer();
-        $this->sourceConfigFactory = new SourceConfigFactory();
-    }
+    ) {}
 
     /**
      * Process imports in a configuration

--- a/src/Config/Import/Source/ImportSourceProvider.php
+++ b/src/Config/Import/Source/ImportSourceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Config\Import\Source;
 
 use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigInterface;
 use Butschster\ContextGenerator\Config\Import\Source\Registry\ImportSourceRegistry;
 use Psr\Log\LoggerInterface;
@@ -15,12 +16,9 @@ use Psr\Log\NullLogger;
  */
 final readonly class ImportSourceProvider
 {
-    /**
-     * @param ImportSourceRegistry $sourceRegistry Pre-configured registry with all registered import sources
-     * @param LoggerInterface|null $logger Optional logger for debugging purposes
-     */
     public function __construct(
         private ImportSourceRegistry $sourceRegistry,
+        #[LoggerPrefix(prefix: 'import-sources')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Config/Import/Source/Local/LocalImportSource.php
+++ b/src/Config/Import/Source/Local/LocalImportSource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Import\Source\Local;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Import\Source\AbstractImportSource;
 use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigInterface;
 use Butschster\ContextGenerator\Config\Import\Source\Exception;
@@ -15,6 +16,7 @@ use Spiral\Files\FilesInterface;
 /**
  * Import source for local filesystem configurations
  */
+#[LoggerPrefix(prefix: 'import-source-local')]
 final class LocalImportSource extends AbstractImportSource
 {
     public function __construct(

--- a/src/Config/Import/Source/Url/UrlImportSource.php
+++ b/src/Config/Import/Source/Url/UrlImportSource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Import\Source\Url;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Import\Source\AbstractImportSource;
 use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigInterface;
 use Butschster\ContextGenerator\Config\Import\Source\Exception;
@@ -16,6 +17,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Import source for remote URL configurations
  */
+#[LoggerPrefix(prefix: 'import-source-url')]
 final class UrlImportSource extends AbstractImportSource
 {
     private int $lastFetchTime = 0;

--- a/src/Config/Import/WildcardPathFinder.php
+++ b/src/Config/Import/WildcardPathFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Import;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Psr\Log\LoggerInterface;
 use Spiral\Files\FilesInterface;
 use Symfony\Component\Finder\Finder;
@@ -20,6 +21,7 @@ final readonly class WildcardPathFinder
 
     public function __construct(
         private FilesInterface $files,
+        #[LoggerPrefix(prefix: 'wildcard-path-finder')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Config/Loader/ConfigLoaderFactory.php
+++ b/src/Config/Loader/ConfigLoaderFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Config\Loader;
 
 use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Parser\CompositeConfigParser;
 use Butschster\ContextGenerator\Config\Parser\ConfigParser;
 use Butschster\ContextGenerator\Config\Parser\ParserPluginRegistry;
@@ -22,6 +23,7 @@ final readonly class ConfigLoaderFactory implements ConfigLoaderFactoryInterface
         private ConfigReaderRegistry $readers,
         private ParserPluginRegistry $pluginRegistry,
         private DirectoriesInterface $dirs,
+        #[LoggerPrefix(prefix: 'config-loader')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Config/Parser/VariablesParserPlugin.php
+++ b/src/Config/Parser/VariablesParserPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Parser;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
 use Butschster\ContextGenerator\Lib\Variable\Provider\ConfigVariableProvider;
 use Psr\Log\LoggerInterface;
@@ -15,6 +16,7 @@ final readonly class VariablesParserPlugin implements ConfigParserPluginInterfac
 {
     public function __construct(
         private ConfigVariableProvider $variableProvider,
+        #[LoggerPrefix(prefix: 'variables-parser')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Config/Reader/JsonReader.php
+++ b/src/Config/Reader/JsonReader.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Reader;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Exception\ReaderException;
 
 /**
  * Reader for JSON configuration files
  */
+#[LoggerPrefix(prefix: 'json-reader')]
 final readonly class JsonReader extends AbstractReader
 {
     public function getSupportedExtensions(): array

--- a/src/Config/Reader/PhpReader.php
+++ b/src/Config/Reader/PhpReader.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Reader;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Exception\ReaderException;
 use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
 
 /**
  * Reader for PHP configuration files
  */
+#[LoggerPrefix(prefix: 'php-reader')]
 final readonly class PhpReader extends AbstractReader
 {
     #[\Override]

--- a/src/Config/Reader/YamlReader.php
+++ b/src/Config/Reader/YamlReader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Reader;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Exception\ReaderException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -11,6 +12,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Reader for YAML configuration files
  */
+#[LoggerPrefix(prefix: 'yaml-reader')]
 final readonly class YamlReader extends AbstractReader
 {
     public function getSupportedExtensions(): array

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -8,6 +8,7 @@ use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
 use Butschster\ContextGenerator\Application\Logger\LoggerFactory;
 use Psr\Log\LoggerInterface;
 use Spiral\Console\Command;
+use Spiral\Core\BinderInterface;
 use Spiral\Core\Scope;
 use Spiral\Core\ScopeInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,10 +40,15 @@ abstract class BaseCommand extends Command
         \assert($this->logger instanceof HasPrefixLoggerInterface);
         \assert($this->logger instanceof LoggerInterface);
 
+        $this->container
+            ->get(BinderInterface::class)
+            ->getBinder('root')
+            ->bind(HasPrefixLoggerInterface::class, $logger);
+
         return $this->container->get(ScopeInterface::class)->runScope(
             bindings: new Scope(
                 bindings: [
-                    LoggerInterface::class => $logger,
+                    // LoggerInterface::class => $logger,
                     HasPrefixLoggerInterface::class => $logger,
                 ],
             ),

--- a/src/Console/MCPServerCommand.php
+++ b/src/Console/MCPServerCommand.php
@@ -14,7 +14,6 @@ use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
 use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\McpServer\ServerRunnerInterface;
 use Monolog\Level;
-use Psr\Log\LoggerInterface;
 use Spiral\Console\Attribute\Option;
 use Spiral\Core\Container;
 use Spiral\Core\Scope;
@@ -59,13 +58,16 @@ final class MCPServerCommand extends BaseCommand
             },
         );
 
+        $container->getBinder('root')->bind(
+            HasPrefixLoggerInterface::class,
+            $logger,
+        );
+
         $logger->info('Starting MCP server...');
 
         return $container->runScope(
             bindings: new Scope(
                 bindings: [
-                    LoggerInterface::class => $logger,
-                    HasPrefixLoggerInterface::class => $logger,
                     DirectoriesInterface::class => $dirs,
                 ],
             ),

--- a/src/Document/Compiler/DocumentCompiler.php
+++ b/src/Document/Compiler/DocumentCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Document\Compiler;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Document\Compiler\Error\ErrorCollection;
 use Butschster\ContextGenerator\Document\Compiler\Error\SourceError;
 use Butschster\ContextGenerator\Document\Document;
@@ -33,6 +34,7 @@ final readonly class DocumentCompiler
         private SourceModifierRegistry $modifierRegistry,
         private VariableResolver $variables,
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
+        #[LoggerPrefix(prefix: 'document-compiler')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Document/DocumentsParserPlugin.php
+++ b/src/Document/DocumentsParserPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Document;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Parser\ConfigParserPluginInterface;
 use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
 use Butschster\ContextGenerator\Modifier\Alias\ModifierResolver;
@@ -19,6 +20,7 @@ final readonly class DocumentsParserPlugin implements ConfigParserPluginInterfac
     public function __construct(
         private SourceProviderInterface $sources,
         private ModifierResolver $modifierResolver = new ModifierResolver(),
+        #[LoggerPrefix(prefix: 'documents-parser-plugin')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Lib/ComposerClient/FileSystemComposerClient.php
+++ b/src/Lib/ComposerClient/FileSystemComposerClient.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Lib\ComposerClient;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Source\Composer\Exception\ComposerNotFoundException;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
+use Spiral\Files\Exception\FilesException;
+use Spiral\Files\FilesInterface;
 
 /**
  * Client that interacts with Composer package data through the filesystem
@@ -14,7 +16,9 @@ use Psr\Log\NullLogger;
 final readonly class FileSystemComposerClient implements ComposerClientInterface
 {
     public function __construct(
-        private LoggerInterface $logger = new NullLogger(),
+        private FilesInterface $files,
+        #[LoggerPrefix(prefix: 'composer-client')]
+        private ?LoggerInterface $logger = null,
     ) {}
 
     public function loadComposerData(string $path): array
@@ -25,22 +29,18 @@ final readonly class FileSystemComposerClient implements ComposerClientInterface
         }
 
         // Check if composer.json exists
-        if (!\file_exists($path)) {
-            $this->logger->error('composer.json not found', ['path' => $path]);
+        if (!$this->files->exists($path)) {
+            $this->logger?->error('composer.json not found', ['path' => $path]);
             throw ComposerNotFoundException::fileNotFound($path);
         }
 
         // Read composer.json
-        $composerJson = \file_get_contents($path);
-        if ($composerJson === false) {
-            $this->logger->error('Failed to read composer.json', ['path' => $path]);
-            throw ComposerNotFoundException::cannotParse($path, 'Failed to read file');
-        }
+        $composerJson = $this->files->read($path);
 
         // Parse composer.json
         $composerData = \json_decode($composerJson, true);
         if (!\is_array($composerData) || \json_last_error() !== JSON_ERROR_NONE) {
-            $this->logger->error('Failed to parse composer.json', [
+            $this->logger?->error('Failed to parse composer.json', [
                 'path' => $path,
                 'error' => \json_last_error_msg(),
             ]);
@@ -54,22 +54,26 @@ final readonly class FileSystemComposerClient implements ComposerClientInterface
     {
         $lockPath = \rtrim($path, '/') . '/composer.lock';
 
-        if (!\file_exists($lockPath)) {
-            $this->logger->info('composer.lock not found', ['path' => $lockPath]);
+        if (!$this->files->exists($lockPath)) {
+            $this->logger?->info('composer.lock not found', ['path' => $lockPath]);
             return null;
         }
 
         // Read composer.lock
-        $lockJson = \file_get_contents($lockPath);
-        if ($lockJson === false) {
-            $this->logger->warning('Failed to read composer.lock', ['path' => $lockPath]);
+        try {
+            $lockJson = $this->files->read($lockPath);
+        } catch (FilesException $e) {
+            $this->logger?->error('Failed to read composer.lock', [
+                'path' => $lockPath,
+                'error' => $e->getMessage(),
+            ]);
             return null;
         }
 
         // Parse composer.lock
         $lockData = \json_decode($lockJson, true);
         if (!\is_array($lockData) || \json_last_error() !== JSON_ERROR_NONE) {
-            $this->logger->warning('Failed to parse composer.lock', [
+            $this->logger?->warning('Failed to parse composer.lock', [
                 'path' => $lockPath,
                 'error' => \json_last_error_msg(),
             ]);
@@ -99,7 +103,7 @@ final readonly class FileSystemComposerClient implements ComposerClientInterface
 
         foreach ($possibleVendorDirs as $dir) {
             if (\is_dir($basePath . '/' . $dir)) {
-                $this->logger->info('Found alternative vendor directory', ['directory' => $dir]);
+                $this->logger?->info('Found alternative vendor directory', ['directory' => $dir]);
                 return $dir;
             }
         }

--- a/src/Lib/Variable/VariableReplacementProcessor.php
+++ b/src/Lib/Variable/VariableReplacementProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Lib\Variable;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Variable\Provider\PredefinedVariableProvider;
 use Butschster\ContextGenerator\Lib\Variable\Provider\VariableProviderInterface;
 use Psr\Log\LoggerInterface;
@@ -15,6 +16,7 @@ final readonly class VariableReplacementProcessor
 {
     public function __construct(
         private VariableProviderInterface $provider = new PredefinedVariableProvider(),
+        #[LoggerPrefix(prefix: 'variable-replacement')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/McpServer/Action/Prompts/FilesystemOperationsAction.php
+++ b/src/McpServer/Action/Prompts/FilesystemOperationsAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\McpServer\Action\Prompts;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\McpServer\Attribute\Prompt;
 use Butschster\ContextGenerator\McpServer\Routing\Attribute\Get;
 use Mcp\Types\GetPromptResult;
@@ -20,6 +21,7 @@ use Psr\Log\LoggerInterface;
 final readonly class FilesystemOperationsAction
 {
     public function __construct(
+        #[LoggerPrefix(prefix: 'prompts.filesystem-ops')]
         private LoggerInterface $logger,
     ) {}
 

--- a/src/McpServer/Action/Prompts/GetPromptAction.php
+++ b/src/McpServer/Action/Prompts/GetPromptAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\McpServer\Action\Prompts;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\McpServer\Prompt\PromptProviderInterface;
 use Butschster\ContextGenerator\McpServer\Routing\Attribute\Get;
@@ -16,6 +17,7 @@ use Psr\Log\LoggerInterface;
 final readonly class GetPromptAction
 {
     public function __construct(
+        #[LoggerPrefix(prefix: 'prompts.get')]
         private LoggerInterface $logger,
         private PromptProviderInterface $prompts,
         private VariableResolver $variables,

--- a/src/McpServer/Action/Prompts/ListPromptsAction.php
+++ b/src/McpServer/Action/Prompts/ListPromptsAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\McpServer\Action\Prompts;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
 use Butschster\ContextGenerator\McpServer\Prompt\PromptProviderInterface;
 use Butschster\ContextGenerator\McpServer\Registry\McpItemsRegistry;
@@ -15,6 +16,7 @@ use Psr\Log\LoggerInterface;
 final readonly class ListPromptsAction
 {
     public function __construct(
+        #[LoggerPrefix(prefix: 'prompts.list')]
         private LoggerInterface $logger,
         private McpItemsRegistry $registry,
         private PromptProviderInterface $prompts,

--- a/src/McpServer/Action/Prompts/ProjectStructurePromptAction.php
+++ b/src/McpServer/Action/Prompts/ProjectStructurePromptAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\McpServer\Action\Prompts;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\McpServer\Attribute\Prompt;
 use Butschster\ContextGenerator\McpServer\Routing\Attribute\Get;
 use Mcp\Types\GetPromptResult;
@@ -20,6 +21,7 @@ use Psr\Log\LoggerInterface;
 final readonly class ProjectStructurePromptAction
 {
     public function __construct(
+        #[LoggerPrefix(prefix: 'prompts.project-structure')]
         private LoggerInterface $logger,
     ) {}
 

--- a/src/McpServer/Action/Resources/GetDocumentContentResourceAction.php
+++ b/src/McpServer/Action/Resources/GetDocumentContentResourceAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\McpServer\Action\Resources;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
 use Butschster\ContextGenerator\Document\Compiler\Error\ErrorCollection;
@@ -16,6 +17,7 @@ use Psr\Log\LoggerInterface;
 final readonly class GetDocumentContentResourceAction
 {
     public function __construct(
+        #[LoggerPrefix(prefix: 'resources.ctx.document')]
         private LoggerInterface $logger,
         private ConfigLoaderInterface $configLoader,
         private DocumentCompiler $compiler,

--- a/src/McpServer/Action/Resources/JsonSchemaResourceAction.php
+++ b/src/McpServer/Action/Resources/JsonSchemaResourceAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\McpServer\Action\Resources;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\McpServer\Attribute\Resource;
 use Butschster\ContextGenerator\McpServer\Routing\Attribute\Get;
@@ -22,6 +23,7 @@ use Spiral\Files\FilesInterface;
 final readonly class JsonSchemaResourceAction
 {
     public function __construct(
+        #[LoggerPrefix(prefix: 'resources.ctx.json-schema')]
         private LoggerInterface $logger,
         private FilesInterface $files,
         private DirectoriesInterface $dirs,

--- a/src/McpServer/Action/Resources/ListResourcesAction.php
+++ b/src/McpServer/Action/Resources/ListResourcesAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\McpServer\Action\Resources;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
 use Butschster\ContextGenerator\McpServer\McpConfig;
 use Butschster\ContextGenerator\McpServer\Registry\McpItemsRegistry;
@@ -16,6 +17,7 @@ use Psr\Log\LoggerInterface;
 final readonly class ListResourcesAction
 {
     public function __construct(
+        #[LoggerPrefix(prefix: 'resources.list')]
         private LoggerInterface $logger,
         private ConfigLoaderInterface $configLoader,
         private McpItemsRegistry $registry,

--- a/src/Source/Composer/ComposerSourceFetcher.php
+++ b/src/Source/Composer/ComposerSourceFetcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\Composer;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Lib\TreeBuilder\FileTreeBuilder;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
@@ -31,6 +32,7 @@ final readonly class ComposerSourceFetcher implements SourceFetcherInterface
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
         private FileTreeBuilder $treeBuilder = new FileTreeBuilder(),
         private VariableResolver $variableResolver = new VariableResolver(),
+        #[LoggerPrefix(prefix: 'composer-source-fetcher')]
         private ?LoggerInterface $logger = null,
     ) {
         // Create a FileSourceFetcher to handle the actual file fetching

--- a/src/Source/Composer/Provider/LocalComposerProvider.php
+++ b/src/Source/Composer/Provider/LocalComposerProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Source\Composer\Provider;
 
 use Butschster\ContextGenerator\Lib\ComposerClient\ComposerClientInterface;
-use Butschster\ContextGenerator\Lib\ComposerClient\FileSystemComposerClient;
 use Butschster\ContextGenerator\Source\Composer\Package\ComposerPackageCollection;
 use Butschster\ContextGenerator\Source\Composer\Package\ComposerPackageInfo;
 use Psr\Log\LoggerInterface;
@@ -14,7 +13,7 @@ use Psr\Log\NullLogger;
 final readonly class LocalComposerProvider extends AbstractComposerProvider
 {
     public function __construct(
-        ComposerClientInterface $client = new FileSystemComposerClient(),
+        ComposerClientInterface $client,
         private string $basePath = '.',
         LoggerInterface $logger = new NullLogger(),
     ) {

--- a/src/Source/File/FileSourceBootloader.php
+++ b/src/Source/File/FileSourceBootloader.php
@@ -10,6 +10,7 @@ use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Source\Registry\SourceRegistryInterface;
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\FactoryInterface;
 
 final class FileSourceBootloader extends Bootloader
 {
@@ -18,14 +19,13 @@ final class FileSourceBootloader extends Bootloader
     {
         return [
             FileSourceFetcher::class => static fn(
+                FactoryInterface $factory,
                 DirectoriesInterface $dirs,
                 ContentBuilderFactory $builderFactory,
                 HasPrefixLoggerInterface $logger,
-            ): FileSourceFetcher => new FileSourceFetcher(
-                basePath: (string) $dirs->getRootPath(),
-                builderFactory: $builderFactory,
-                logger: $logger->withPrefix('file-source'),
-            ),
+            ): FileSourceFetcher => $factory->make(FileSourceFetcher::class, [
+                'basePath' => (string) $dirs->getRootPath(),
+            ]),
         ];
     }
 

--- a/src/Source/File/FileSourceFetcher.php
+++ b/src/Source/File/FileSourceFetcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\File;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Lib\Finder\FinderInterface;
 use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
@@ -18,16 +19,11 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 final readonly class FileSourceFetcher implements SourceFetcherInterface
 {
-    /**
-     * @param string $basePath Base path for relative file references
-     * @param FinderInterface $finder Finder for locating files
-     * @param ContentBuilderFactory $builderFactory Factory for creating ContentBuilder instances
-     * @param LoggerInterface|null $logger PSR Logger instance
-     */
     public function __construct(
         private string $basePath,
         private FinderInterface $finder = new SymfonyFinder(),
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
+        #[LoggerPrefix(prefix: 'file-source')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Source/GitDiff/GitDiffSourceBootloader.php
+++ b/src/Source/GitDiff/GitDiffSourceBootloader.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Source\GitDiff;
 
 use Butschster\ContextGenerator\Application\Bootloader\SourceFetcherBootloader;
-use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
-use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
+use Butschster\ContextGenerator\Source\GitDiff\Git\GitClient;
+use Butschster\ContextGenerator\Source\GitDiff\Git\GitClientInterface;
 use Butschster\ContextGenerator\Source\Registry\SourceRegistryInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 
@@ -16,13 +16,8 @@ final class GitDiffSourceBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
-            GitDiffSourceFetcher::class => static fn(
-                ContentBuilderFactory $builderFactory,
-                HasPrefixLoggerInterface $logger,
-            ): GitDiffSourceFetcher => new GitDiffSourceFetcher(
-                builderFactory: $builderFactory,
-                logger: $logger->withPrefix('commit-diff-source'),
-            ),
+            GitClientInterface::class => GitClient::class,
+            GitDiffSourceFetcher::class => GitDiffSourceFetcher::class,
         ];
     }
 

--- a/src/Source/Github/GithubSourceBootloader.php
+++ b/src/Source/Github/GithubSourceBootloader.php
@@ -6,8 +6,6 @@ namespace Butschster\ContextGenerator\Source\Github;
 
 use Butschster\ContextGenerator\Application\Bootloader\GithubClientBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\SourceFetcherBootloader;
-use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
-use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Source\Registry\SourceRegistryInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 
@@ -23,15 +21,7 @@ final class GithubSourceBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
-            GithubSourceFetcher::class => static fn(
-                HasPrefixLoggerInterface $logger,
-                GithubFinder $finder,
-                ContentBuilderFactory $builderFactory,
-            ): GithubSourceFetcher => new GithubSourceFetcher(
-                finder: $finder,
-                builderFactory: $builderFactory,
-                logger: $logger->withPrefix('github-source'),
-            ),
+            GithubSourceFetcher::class => GithubSourceFetcher::class,
         ];
     }
 

--- a/src/Source/Github/GithubSourceFetcher.php
+++ b/src/Source/Github/GithubSourceFetcher.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\Github;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
-use Butschster\ContextGenerator\Lib\Finder\FinderInterface;
 use Butschster\ContextGenerator\Lib\GithubClient\Model\GithubRepository;
 use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
 use Butschster\ContextGenerator\Source\Fetcher\SourceFetcherInterface;
@@ -20,8 +20,9 @@ use Psr\Log\LoggerInterface;
 final readonly class GithubSourceFetcher implements SourceFetcherInterface
 {
     public function __construct(
-        private FinderInterface $finder,
+        private GithubFinder $finder,
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
+        #[LoggerPrefix(prefix: 'github-source')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Source/Registry/SourceRegistry.php
+++ b/src/Source/Registry/SourceRegistry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\Registry;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Source\SourceInterface;
 use Psr\Log\LoggerInterface;
 
@@ -18,6 +19,7 @@ final class SourceRegistry implements SourceRegistryInterface, SourceProviderInt
     private array $factories = [];
 
     public function __construct(
+        #[LoggerPrefix(prefix: 'source-registry')]
         private readonly ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Source/Registry/SourceRegistryBootloader.php
+++ b/src/Source/Registry/SourceRegistryBootloader.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\Registry;
 
-use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Core\Attribute\Singleton;
 
@@ -17,11 +16,7 @@ final class SourceRegistryBootloader extends Bootloader
         return [
             SourceRegistryInterface::class => SourceRegistry::class,
             SourceProviderInterface::class => SourceRegistry::class,
-            SourceRegistry::class => static fn(
-                HasPrefixLoggerInterface $logger,
-            ): SourceRegistryInterface => new SourceRegistry(
-                logger: $logger->withPrefix('source-registry'),
-            ),
+            SourceRegistry::class => SourceRegistry::class,
         ];
     }
 }

--- a/src/Source/Text/TextSourceBootloader.php
+++ b/src/Source/Text/TextSourceBootloader.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Source\Text;
 
 use Butschster\ContextGenerator\Application\Bootloader\SourceFetcherBootloader;
-use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
-use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
-use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Source\Registry\SourceRegistryInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 
@@ -17,15 +14,7 @@ final class TextSourceBootloader extends Bootloader
     public function defineSingletons(): array
     {
         return [
-            TextSourceFetcher::class => static fn(
-                ContentBuilderFactory $builderFactory,
-                VariableResolver $variables,
-                HasPrefixLoggerInterface $logger,
-            ): TextSourceFetcher => new TextSourceFetcher(
-                builderFactory: $builderFactory,
-                variableResolver: $variables,
-                logger: $logger->withPrefix('text-source'),
-            ),
+            TextSourceFetcher::class => TextSourceFetcher::class,
         ];
     }
 

--- a/src/Source/Text/TextSourceFetcher.php
+++ b/src/Source/Text/TextSourceFetcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\Text;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Content\Block\TextBlock;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
@@ -21,6 +22,7 @@ final readonly class TextSourceFetcher implements SourceFetcherInterface
     public function __construct(
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
         private VariableResolver $variableResolver = new VariableResolver(),
+        #[LoggerPrefix(prefix: 'text-source')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Source/Tree/TreeSourceBootloader.php
+++ b/src/Source/Tree/TreeSourceBootloader.php
@@ -10,6 +10,7 @@ use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Source\Registry\SourceRegistryInterface;
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\FactoryInterface;
 
 final class TreeSourceBootloader extends Bootloader
 {
@@ -18,14 +19,13 @@ final class TreeSourceBootloader extends Bootloader
     {
         return [
             TreeSourceFetcher::class => static fn(
+                FactoryInterface $factory,
                 DirectoriesInterface $dirs,
                 ContentBuilderFactory $builderFactory,
                 HasPrefixLoggerInterface $logger,
-            ): TreeSourceFetcher => new TreeSourceFetcher(
-                basePath: (string) $dirs->getRootPath(),
-                builderFactory: $builderFactory,
-                logger: $logger->withPrefix('tree-source'),
-            ),
+            ): TreeSourceFetcher => $factory->make(TreeSourceFetcher::class, [
+                'basePath' => (string) $dirs->getRootPath(),
+            ]),
         ];
     }
 

--- a/src/Source/Tree/TreeSourceFetcher.php
+++ b/src/Source/Tree/TreeSourceFetcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\Tree;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
 use Butschster\ContextGenerator\Source\Fetcher\SourceFetcherInterface;
@@ -17,16 +18,11 @@ use Psr\Log\LoggerInterface;
  */
 final readonly class TreeSourceFetcher implements SourceFetcherInterface
 {
-    /**
-     * @param string $basePath Base path for relative file references
-     * @param ContentBuilderFactory $builderFactory Factory for creating ContentBuilder instances
-     * @param SymfonyFinder $finder Finder for filtering files
-     * @param LoggerInterface|null $logger PSR Logger instance
-     */
     public function __construct(
         private string $basePath,
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
         private SymfonyFinder $finder = new SymfonyFinder(),
+        #[LoggerPrefix(prefix: 'tree-source')]
         private ?LoggerInterface $logger = null,
     ) {}
 

--- a/src/Source/Url/UrlSourceBootloader.php
+++ b/src/Source/Url/UrlSourceBootloader.php
@@ -12,6 +12,7 @@ use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Source\Registry\SourceRegistryInterface;
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\FactoryInterface;
 
 final class UrlSourceBootloader extends Bootloader
 {
@@ -26,16 +27,18 @@ final class UrlSourceBootloader extends Bootloader
     {
         return [
             UrlSourceFetcher::class => static fn(
+                FactoryInterface $factory,
                 ContentBuilderFactory $builderFactory,
                 HttpClientInterface $httpClient,
                 VariableResolver $variables,
                 HasPrefixLoggerInterface $logger,
-            ): UrlSourceFetcher => new UrlSourceFetcher(
-                httpClient: $httpClient,
-                variableResolver: $variables,
-                builderFactory: $builderFactory,
-                logger: $logger->withPrefix('url-source'),
-            ),
+            ): UrlSourceFetcher => $factory->make(UrlSourceFetcher::class, [
+                'defaultHeaders' => [
+                    'User-Agent' => 'Context Generator Bot',
+                    'Accept' => 'text/html,application/xhtml+xml',
+                    'Accept-Language' => 'en-US,en;q=0.9',
+                ],
+            ]),
         ];
     }
 

--- a/src/Source/Url/UrlSourceFetcher.php
+++ b/src/Source/Url/UrlSourceFetcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\Url;
 
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Lib\Html\HtmlCleaner;
 use Butschster\ContextGenerator\Lib\Html\HtmlCleanerInterface;
@@ -24,7 +25,6 @@ final readonly class UrlSourceFetcher implements SourceFetcherInterface
 {
     /**
      * @param array<string, string> $defaultHeaders Default HTTP headers to use for all requests
-     * @param LoggerInterface|null $logger PSR Logger instance
      */
     public function __construct(
         private HttpClientInterface $httpClient,
@@ -37,6 +37,7 @@ final readonly class UrlSourceFetcher implements SourceFetcherInterface
         private HtmlCleanerInterface $cleaner = new HtmlCleaner(),
         private ?SelectorContentExtractorInterface $selectorExtractor = new SelectorContentExtractor(),
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
+        #[LoggerPrefix(prefix: 'url-source')]
         private ?LoggerInterface $logger = null,
     ) {}
 


### PR DESCRIPTION
This PR introduces a more elegant approach to logger prefix management by leveraging PHP attributes. Instead of manually configuring logger prefixes in bootloaders, we now use a declarative approach with attributes.

#### Key Improvements:

1. **Attribute-Based Logger Naming**:
   - Added `LoggerPrefix` attribute that can be applied to parameters, properties or classes
   - Simplified code by removing redundant logger prefix assignments in bootloaders

2. **Automatic DI Resolution**:
   - Enhanced `LoggerBootloader` to implement `InjectorInterface`
   - Automatically detects and applies prefixes during dependency injection
   - Extracts prefix from attribute or falls back to class name

3. **Consistent Logger Prefixing**:
   - Applied `LoggerPrefix` attributes consistently across all services
   - Classes now explicitly declare their preferred logger prefix
   - Unified prefix naming convention throughout the codebase

4. **Cleaner Bootloader Implementation**:
   - Removed repetitive withPrefix() calls from bootloaders
   - Factory-based instantiation for cleanly passing dependencies
   - Each component now declares its own logging requirements

This approach significantly reduces boilerplate code while making logger prefix configuration more transparent and maintainable. Services now self-document their logging requirements directly at the class or parameter level.

### Example: Before and After

#### Before this PR:

```php
// In Bootloader
public function defineSingletons(): array
{
    return [
        ImportSourceProvider::class => static fn(
            ImportSourceRegistry $sourceRegistry,
            HasPrefixLoggerInterface $logger,
        ) => new ImportSourceProvider(
            sourceRegistry: $sourceRegistry,
            logger: $logger->withPrefix('import-sources'),
        ),
        
        UrlImportSource::class => static fn(
            HttpClientInterface $httpClient,
            VariableResolver $variables,
            HasPrefixLoggerInterface $logger,
        ) => new UrlImportSource(
            httpClient: $httpClient,
            variables: $variables,
            logger: $logger->withPrefix('import-source-url'),
        ),
        
        // ...dozens more similar declarations
    ];
}

// In Service class
public function __construct(
    private ImportSourceRegistry $sourceRegistry,
    private ?LoggerInterface $logger = null,
) {}
```

#### After this PR:

```php
// In Bootloader - much cleaner!
public function defineSingletons(): array
{
    return [
        ImportSourceProvider::class => ImportSourceProvider::class,
        UrlImportSource::class => UrlImportSource::class,
    ];
}

// In Service class - self-documenting logger prefix
public function __construct(
    private ImportSourceRegistry $sourceRegistry,
    #[LoggerPrefix(prefix: 'import-sources')]
    private ?LoggerInterface $logger = null,
) {}

// Or simply at class level
#[LoggerPrefix(prefix: 'import-source-url')]
final class UrlImportSource extends AbstractImportSource
{
    // No need to specify prefix in constructor
    public function __construct(
        private HttpClientInterface $httpClient,
        private VariableResolver $variables,
        private ?LoggerInterface $logger = null,
    ) {}
}
```