### PR TITLE
Add custom tools configuration and execution support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .output
 composer.lock
 coverage
-docs
 vendor
 node_modules
 .php-cs-fixer.cache

--- a/context.yaml
+++ b/context.yaml
@@ -6,6 +6,31 @@ import:
 variables:
   name: Context Generator
 
+tools:
+  - id: run-tests
+    description: Run unit tests
+    env:
+      COMPOSER_ALLOW_SUPERUSER: 'true'
+    commands:
+      - cmd: composer
+        args:
+          - test
+
+  - id: code-quality
+    description: Run code quality checks
+    env:
+      COMPOSER_ALLOW_SUPERUSER: 'true'
+    commands:
+      - cmd: composer
+        args:
+          - cs-fix
+      - cmd: composer
+        args:
+          - refactor
+      - cmd: composer
+        args:
+          - psalm
+
 prompts:
   - id: my-local-prompt
     description: My local prompt

--- a/docs/config/config-system-guide.md
+++ b/docs/config/config-system-guide.md
@@ -1,0 +1,442 @@
+# Configuration System Guide
+
+## 1. Overview
+
+The Configuration System is a flexible framework for loading, parsing, and managing configuration data from various
+sources. It supports multiple file formats (JSON, YAML, PHP), imports from local and remote sources, and provides a
+plugin-based architecture for extending functionality.
+
+## 2. Purpose and Use Cases
+
+This system is designed to:
+
+- Load configuration from local or remote sources
+- Support multiple configuration formats (JSON, YAML, PHP)
+- Allow importing configurations from other locations
+- Process configuration through a plugin pipeline
+- Compile documents based on the configuration
+
+**Common Use Cases:**
+
+- Loading application configuration settings
+- Creating a documentation builder that compiles documents from various sources
+- Building a context generator that imports and processes content from different locations
+
+## 3. Core Components Breakdown
+
+### 3.1 Configuration Loading
+
+The configuration loading process is handled by several key components:
+
+#### `ConfigLoaderInterface`
+
+The primary interface for configuration loaders, which defines methods for loading configurations.
+
+```php
+interface ConfigLoaderInterface
+{
+    public function load(): RegistryInterface;
+    public function loadRawConfig(): array;
+    public function isSupported(): bool;
+}
+```
+
+#### `ConfigLoader`
+
+The main implementation of `ConfigLoaderInterface` that uses readers and parsers to load configuration:
+
+```php
+final readonly class ConfigLoader implements ConfigLoaderInterface
+{
+    public function __construct(
+        private string $configPath,
+        private ReaderInterface $reader,
+        private ConfigParserInterface $parser,
+        private ?LoggerInterface $logger = null,
+    ) {}
+    
+    // Implementation methods
+}
+```
+
+#### `ConfigLoaderFactory`
+
+Creates configuration loaders based on different scenarios:
+
+```php
+final readonly class ConfigLoaderFactory implements ConfigLoaderFactoryInterface
+{
+    // Creates loaders for directories, specific files, or string content
+    public function create(string $configPath): ConfigLoaderInterface;
+    public function createForFile(string $configPath): ConfigLoaderInterface;
+    public function createFromString(string $jsonConfig): ConfigLoaderInterface;
+}
+```
+
+#### `ConfigurationProvider`
+
+Provides helpers for loading configuration from different sources:
+
+```php
+final readonly class ConfigurationProvider
+{
+    // Different methods for loading configuration
+    public function fromString(string $jsonConfig): ConfigLoaderInterface;
+    public function fromPath(string $configPath): ConfigLoaderInterface;
+    public function fromDefaultLocation(): ConfigLoaderInterface;
+}
+```
+
+### 3.2 Configuration Readers
+
+Readers handle reading and parsing specific file formats:
+
+#### `ReaderInterface`
+
+```php
+interface ReaderInterface
+{
+    public function read(string $path): array;
+    public function supports(string $path): bool;
+    public function getSupportedExtensions(): array;
+}
+```
+
+Available readers:
+
+- `JsonReader` - For JSON files (.json)
+- `YamlReader` - For YAML files (.yaml, .yml)
+- `PhpReader` - For PHP files (.php)
+- `StringJsonReader` - For JSON content provided as a string
+
+### 3.3 Configuration Parsing
+
+The system uses a plugin-based approach to parse configuration:
+
+#### `ConfigParserInterface`
+
+```php
+interface ConfigParserInterface
+{
+    public function parse(array $config): ConfigRegistry;
+}
+```
+
+#### `ConfigParserPluginInterface`
+
+```php
+interface ConfigParserPluginInterface
+{
+    public function getConfigKey(): string;
+    public function updateConfig(array $config, string $rootPath): array;
+    public function parse(array $config, string $rootPath): ?RegistryInterface;
+    public function supports(array $config): bool;
+}
+```
+
+Key parser plugins:
+
+- `ImportParserPlugin` - Handles import directives
+- `DocumentsParserPlugin` - Processes document definitions
+- `VariablesParserPlugin` - Handles variable substitution
+
+### 3.4 Import System
+
+The import system allows loading configuration from external sources:
+
+#### `ImportSourceInterface`
+
+```php
+interface ImportSourceInterface
+{
+    public function getName(): string;
+    public function supports(SourceConfigInterface $config): bool;
+    public function load(SourceConfigInterface $config): array;
+    public function allowedSections(): array;
+}
+```
+
+Available import sources:
+
+- `LocalImportSource` - Imports from local filesystem
+- `UrlImportSource` - Imports from remote URLs
+
+#### `ImportResolver`
+
+Resolves and processes import directives, handling path resolution and circular dependency detection:
+
+```php
+final readonly class ImportResolver
+{
+    public function resolveImports(
+        array $config,
+        string $basePath,
+        array &$parsedImports = [],
+        CircularImportDetectorInterface $detector = new CircularImportDetector(),
+    ): array;
+}
+```
+
+### 3.5 Document Compilation
+
+The document system uses the configuration to compile documents:
+
+#### `Document`
+
+Represents a document to be compiled:
+
+```php
+final class Document implements \JsonSerializable
+{
+    public function __construct(
+        public readonly string $description,
+        public readonly string $outputPath,
+        public readonly bool $overwrite = true,
+        private array $modifiers = [],
+        private array $tags = [],
+        SourceInterface ...$sources,
+    ) {}
+}
+```
+
+#### `DocumentCompiler`
+
+Compiles documents with their sources:
+
+```php
+final readonly class DocumentCompiler
+{
+    public function compile(Document $document): CompiledDocument;
+    public function buildContent(ErrorCollection $errors, Document $document): CompiledDocument;
+}
+```
+
+## 4. Configuration Structure
+
+A typical configuration file structure:
+
+```yaml
+# Optional variable declarations
+variables:
+  BASE_PATH: /path/to/base
+  API_VERSION: v1
+
+# Import other configurations
+import:
+  - path: another-config.yaml  # Local path
+    pathPrefix: api/v1          # Optional prefix for document output paths
+  - type: url
+    url: https://example.com/config.json
+
+# Document definitions
+documents:
+  - description: API Documentation
+    outputPath: docs/api.md
+    overwrite: true    # Whether to overwrite existing file
+    tags: [ api, docs ]  # Optional tags
+    modifiers: [ ... ]   # Optional modifiers
+    sources:
+      - type: file     # Source type
+        sourcePaths: # Paths to source files
+          - src/Api
+          - src/Controllers
+```
+
+## 5. Usage Examples
+
+### Basic Configuration Loading
+
+```php
+// Using the ConfigurationProvider to load configuration
+$provider = $container->get(ConfigurationProvider::class);
+
+// Load from a specific path
+$loader = $provider->fromPath('config/context.yaml');
+$config = $loader->load();
+
+// Load from default location
+$loader = $provider->fromDefaultLocation();
+$config = $loader->load();
+
+// Load from a string
+$jsonString = '{"documents": [...]}';
+$loader = $provider->fromString($jsonString);
+$config = $loader->load();
+```
+
+### Compiling Documents
+
+```php
+// Get the document compiler
+$compiler = $container->get(DocumentCompiler::class);
+
+// Get document registry
+$registry = $container->get(ConfigLoaderInterface::class)->load();
+
+// Compile each document
+foreach ($registry->getItems() as $document) {
+    $result = $compiler->compile($document);
+    
+    if ($result->errors->hasErrors()) {
+        foreach ($result->errors as $error) {
+            echo "Error: $error\n";
+        }
+    }
+}
+```
+
+### Creating Import Sources
+
+```php
+// Creating a local import source
+$localSource = new LocalImportSource($files, $readers);
+
+// Creating a URL import source
+$urlSource = new UrlImportSource($httpClient, $variableResolver);
+
+// Register sources in the registry
+$registry = new ImportSourceRegistry();
+$registry->register($localSource);
+$registry->register($urlSource);
+```
+
+## 6. Architecture Diagram
+
+```
+                 ┌───────────────────┐
+                 │ConfigurationProvider│
+                 └──────────┬────────┘
+                            │
+                            ▼
+┌────────────────┐    ┌─────────────────┐    ┌───────────────────┐
+│ConfigLoaderFactory│─▶│ConfigLoader     │─▶│ConfigParser       │
+└────────────────┘    └─────────────────┘    └───────────┬───────┘
+                                                         │
+                      ┌───────────────────────────────────────────┐
+                      │                                           │
+                      ▼                                           ▼
+             ┌──────────────────┐                     ┌──────────────────┐
+             │Reader (JSON/YAML/PHP)│                     │ParserPluginRegistry│
+             └──────────────────┘                     └──────────┬───────┘
+                                                                 │
+                      ┌───────────────────────────────────────────────┐
+                      │                                           │
+                      ▼                                           ▼
+             ┌──────────────────┐                     ┌──────────────────┐
+             │ImportParserPlugin │                     │DocumentsParserPlugin│
+             └──────────┬───────┘                     └──────────────────┘
+                        │
+                        ▼
+             ┌──────────────────┐
+             │ImportResolver    │
+             └──────────┬───────┘
+                        │
+           ┌────────────┴────────────┐
+           │                         │
+           ▼                         ▼
+┌──────────────────┐       ┌──────────────────┐
+│LocalImportSource │       │UrlImportSource   │
+└──────────────────┘       └──────────────────┘
+```
+
+## 7. Common Implementation Patterns
+
+### 1. Service Registration using Bootloaders
+
+The system uses bootloaders to register services:
+
+```php
+final class ConfigLoaderBootloader extends Bootloader
+{
+    public function defineSingletons(): array
+    {
+        return [
+            // Service registrations
+            ConfigReaderRegistry::class => /* ... */,
+            ConfigLoaderFactoryInterface::class => ConfigLoaderFactory::class,
+            // ...
+        ];
+    }
+}
+```
+
+### 2. Plugin Registration
+
+Plugins are registered in a registry:
+
+```php
+$parserPluginRegistry = new ParserPluginRegistry([
+    $importParserPlugin,
+    $documentsParserPlugin,
+    // Other plugins
+]);
+```
+
+### 3. Error Handling
+
+The system uses specialized exceptions and error collections:
+
+```php
+try {
+    $config = $reader->read($path);
+} catch (ReaderException $e) {
+    $logger->error('Failed to read configuration', [
+        'path' => $path,
+        'error' => $e->getMessage(),
+    ]);
+    // Handle error appropriately
+}
+```
+
+## 8. Best Practices
+
+1. **Use Dependency Injection**: The system is designed to work with a DI container.
+
+2. **Leverage Bootloaders**: Register services through bootloaders to ensure proper initialization order.
+
+3. **Add Logging**: Most components accept a PSR logger for debugging and monitoring.
+
+4. **Use Appropriate Readers**: Select the right reader for each file format.
+
+5. **Handle Import Paths Carefully**: Be mindful of relative and absolute paths when importing.
+
+6. **Watch for Circular Dependencies**: The import system has circular dependency detection but be careful with complex
+   import graphs.
+
+7. **Use Source Prefixing**: When importing configurations, use pathPrefix to organize outputs.
+
+## 9. Extension Points
+
+The system can be extended in several ways:
+
+1. **Custom Readers**: Implement `ReaderInterface` for new file formats.
+
+2. **Parser Plugins**: Create plugins implementing `ConfigParserPluginInterface`.
+
+3. **Import Sources**: Implement `ImportSourceInterface` for new import sources.
+
+4. **Document Sources**: Create new sources implementing `SourceInterface`.
+
+5. **Modifiers**: Create modifiers that implement `Modifier` interface.
+
+## 10. Troubleshooting
+
+### Common Issues
+
+1. **Configuration not found**
+    - Check if the file exists and is readable
+    - Verify the path is correct (relative vs. absolute)
+
+2. **Import failures**
+    - Check network connectivity for URL imports
+    - Verify file permissions for local imports
+    - Look for circular dependencies
+
+3. **Parsing errors**
+    - Validate the syntax of JSON/YAML files
+    - Check for proper structure and required fields
+
+4. **Document compilation issues**
+    - Check if sources exist and are accessible
+    - Verify output directories are writable
+    - Look for errors in source parsing

--- a/docs/config/import-system-guide.md
+++ b/docs/config/import-system-guide.md
@@ -1,0 +1,548 @@
+# Import System Guide
+
+## 1. Overview
+
+The Import System is a component of the Configuration System that allows loading and merging configuration from multiple
+sources, both local files and remote URLs. It provides a flexible way to organize configuration across multiple files,
+reuse common configurations, and fetch remote configurations.
+
+## 2. Purpose and Use Cases
+
+The Import System serves several key purposes:
+
+- **Modularize Configuration**: Split large configuration files into smaller, more manageable pieces
+- **Share Common Configurations**: Reuse configuration components across multiple projects
+- **Fetch Remote Configurations**: Load configuration from remote sources like APIs or repositories
+- **Create Configuration Hierarchies**: Build layered configurations with defaults and overrides
+
+**Common Use Cases:**
+
+- Importing base configuration templates
+- Splitting a large context configuration into smaller domain-specific files
+- Fetching remote configurations maintained in a central repository
+- Creating organization-wide configuration standards with local overrides
+
+## 3. Components Breakdown
+
+### 3.1 Core Import Components
+
+#### `ImportParserPlugin`
+
+Responsible for processing the `import` section in configuration files:
+
+```php
+final readonly class ImportParserPlugin implements ConfigParserPluginInterface
+{
+    public function __construct(
+        private ImportResolver $importResolver,
+        #[LoggerPrefix(prefix: 'import-parser')]
+        private ?LoggerInterface $logger = null,
+    ) {}
+    
+    // Methods for parsing imports
+}
+```
+
+#### `ImportResolver`
+
+Handles the actual resolution of import sources:
+
+```php
+final readonly class ImportResolver
+{
+    public function resolveImports(
+        array $config,
+        string $basePath,
+        array &$parsedImports = [],
+        CircularImportDetectorInterface $detector = new CircularImportDetector(),
+    ): array;
+    
+    // Methods for handling different import types
+}
+```
+
+#### `CircularImportDetector`
+
+Prevents infinite import loops:
+
+```php
+final class CircularImportDetector implements CircularImportDetectorInterface
+{
+    private array $importStack = [];
+    
+    public function wouldCreateCircularDependency(string $path): bool;
+    public function beginProcessing(string $path): void;
+    public function endProcessing(string $path): void;
+}
+```
+
+### 3.2 Import Sources
+
+The system supports different types of import sources:
+
+#### `ImportSourceInterface`
+
+The core interface for all import sources:
+
+```php
+interface ImportSourceInterface
+{
+    public function getName(): string;
+    public function supports(SourceConfigInterface $config): bool;
+    public function load(SourceConfigInterface $config): array;
+    public function allowedSections(): array;
+}
+```
+
+#### `AbstractImportSource`
+
+Base implementation for import sources:
+
+```php
+abstract class AbstractImportSource implements ImportSourceInterface
+{
+    protected function readConfig(string $path, ReaderInterface $reader): array;
+    protected function processSelectiveImports(array $config, SourceConfigInterface $sourceConfig): array;
+    // Other helper methods
+}
+```
+
+#### `LocalImportSource`
+
+Imports configuration from local filesystem:
+
+```php
+final class LocalImportSource extends AbstractImportSource
+{
+    public function __construct(
+        private readonly FilesInterface $files,
+        private readonly ConfigReaderRegistry $readers,
+        ?LoggerInterface $logger = null,
+    ) {}
+
+    // Implementation methods
+}
+```
+
+#### `UrlImportSource`
+
+Imports configuration from remote URLs:
+
+```php
+final class UrlImportSource extends AbstractImportSource
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly VariableResolver $variables,
+        ?LoggerInterface $logger = null,
+    ) {}
+
+    // Implementation methods
+}
+```
+
+### 3.3 Import Source Configurations
+
+For each source type, there's a corresponding configuration:
+
+#### `SourceConfigInterface`
+
+```php
+interface SourceConfigInterface
+{
+    public function getPath(): string;
+    public function getType(): string;
+}
+```
+
+#### `LocalSourceConfig`
+
+```php
+final class LocalSourceConfig extends AbstractSourceConfig
+{
+    public function __construct(
+        string $path,
+        private readonly string $absolutePath,
+        private readonly bool $hasWildcard = false,
+        ?string $pathPrefix = null,
+        ?array $selectiveDocuments = null,
+    ) {}
+    
+    // Methods specific to local source config
+}
+```
+
+#### `UrlSourceConfig`
+
+```php
+final readonly class UrlSourceConfig implements SourceConfigInterface
+{
+    public function __construct(
+        public string $url,
+        public int $ttl = 300,
+        public readonly array $headers = [],
+    ) {}
+    
+    // Methods specific to URL source config
+}
+```
+
+### 3.4 Path Handling Components
+
+The system includes utilities for path handling:
+
+#### `PathMatcher`
+
+Converts glob patterns to regex for path matching:
+
+```php
+final readonly class PathMatcher
+{
+    private string $regex;
+    
+    public function __construct(private string $pattern);
+    public static function containsWildcard(string $path): bool;
+    public function isMatch(string $path): bool;
+}
+```
+
+#### `WildcardPathFinder`
+
+Finds files matching a glob pattern:
+
+```php
+final readonly class WildcardPathFinder
+{
+    public function __construct(
+        private FilesInterface $files,
+        #[LoggerPrefix(prefix: 'wildcard-path-finder')]
+        private ?LoggerInterface $logger = null,
+    ) {}
+    
+    public function findMatchingPaths(string $pattern, string $basePath): array;
+}
+```
+
+#### Path Prefixers
+
+Apply prefixes to paths in imported configurations:
+
+- `PathPrefixer` - Base abstract class
+- `DocumentOutputPathPrefixer` - Applies prefixes to document output paths
+- `SourcePathPrefixer` - Applies prefixes to source paths
+
+## 4. Import Configuration Structure
+
+The import section in a configuration file follows this structure:
+
+```yaml
+import:
+  # Local file import (default type)
+  - path: relative/path/to/file.yaml
+
+  # Local file import with explicit type
+  - type: local
+    path: absolute/path/to/file.json
+
+  # Local file import with wildcard matching
+  - path: "configs/*.yaml"
+
+  # Local file import with selective documents
+  - path: all-documents.yaml
+    docs: # Only import specific documents
+      - "api/*.md"
+      - "getting-started.md"
+
+  # Local file import with path prefixing
+  - path: components.yaml
+    pathPrefix: ui/components  # Prefix for document output paths
+
+  # Remote URL import
+  - type: url
+    url: https://example.com/config.json
+    ttl: 3600  # Cache time in seconds
+    headers: # Optional HTTP headers
+      Authorization: "Bearer token123"
+      Accept: "application/json"
+```
+
+## 5. Usage Examples
+
+### Basic Import Usage
+
+```yaml
+# main-config.yaml
+import:
+  - path: base-config.yaml
+  - path: project-specific.yaml
+
+# Additional configuration that might override imported values
+variables:
+  VERSION: 2.0
+
+documents:
+  - description: Combined Documentation
+    outputPath: docs/combined.md
+    # ...
+```
+
+### Importing With Wildcards
+
+```yaml
+# Import all configuration files in a directory
+import:
+  - path: "configs/*.yaml"  # Match all YAML files in configs directory
+  - path: "configs/**/*.yaml"  # Match all YAML files in configs and subdirectories
+```
+
+### Selective Document Import
+
+```yaml
+# Only import specific documents from a configuration file
+import:
+  - path: all-documents.yaml
+    docs:
+      - "api/*.md"  # All API documentation
+      - "getting-started.md"  # Specific document
+```
+
+### URL Import With Authentication
+
+```yaml
+# Import configuration from a remote URL
+import:
+  - type: url
+    url: https://api.example.com/config
+    ttl: 1800  # Cache for 30 minutes
+    headers:
+      Authorization: "Bearer ${API_TOKEN}"  # Variable substitution
+      Accept: "application/json"
+```
+
+### Import With Path Prefixing
+
+```yaml
+# Add prefix to all document output paths in the imported configuration
+import:
+  - path: components.yaml
+    pathPrefix: ui/components
+```
+
+## 6. Architecture Diagram
+
+```
+┌─────────────────┐
+│Configuration File│
+└────────┬────────┘
+         │
+         ▼
+┌────────────────┐    ┌──────────────────┐
+│ImportParserPlugin│──▶│ImportResolver    │
+└────────────────┘    └──────────┬───────┘
+                                 │
+         ┌─────────────────────────────────────────┐
+         │                                         │
+         ▼                                         ▼
+┌──────────────────┐                    ┌──────────────────┐
+│LocalSourceConfig │                    │UrlSourceConfig   │
+└──────────┬───────┘                    └──────────┬───────┘
+           │                                       │
+           ▼                                       ▼
+┌──────────────────┐                    ┌──────────────────┐
+│LocalImportSource │                    │UrlImportSource   │
+└──────────┬───────┘                    └──────────┬───────┘
+           │                                       │
+           │                                       │
+           ▼                                       ▼
+    ┌─────────────────┐                   ┌─────────────────┐
+    │Configuration     │                   │Configuration     │
+    │Reader            │                   │from URL         │
+    └─────────┬───────┘                   └─────────┬───────┘
+              │                                     │
+              └────────────────┬──────────────────┘
+                               │
+                               ▼
+                     ┌───────────────────┐
+                     │Merged Configuration│
+                     └───────────────────┘
+```
+
+## 7. Best Practices
+
+### 1. Organize Imports Logically
+
+- Group related configurations in separate files
+- Use a hierarchical structure (base → domain → project)
+- Place common configurations in a shared location
+
+### 2. Be Mindful of Import Order
+
+- Later imports override earlier ones for the same keys
+- Use this to implement layered configurations (defaults → specifics)
+
+### 3. Use Path Prefixing for Organization
+
+- Apply path prefixes to keep output documents organized
+- Match the prefix to the logical structure of your project
+
+### 4. Cache Remote Imports
+
+- Set appropriate TTL values for URL imports
+- Longer for stable configurations, shorter for frequently changing ones
+
+### 5. Use Selective Imports
+
+- Only import what you need to keep configurations clean
+- Use document selectors to pick specific parts of large configurations
+
+### 6. Secure Remote Imports
+
+- Use HTTPS for all URL imports
+- Apply proper authentication headers
+- Consider using environment variables for sensitive tokens
+
+## 8. Extension Points
+
+The Import System can be extended in several ways:
+
+### 1. Custom Import Sources
+
+Create a new import source by implementing `ImportSourceInterface`:
+
+```php
+final class CustomImportSource extends AbstractImportSource
+{
+    public function getName(): string
+    {
+        return 'custom';
+    }
+    
+    public function supports(SourceConfigInterface $config): bool
+    {
+        return $config->getType() === 'custom';
+    }
+    
+    public function load(SourceConfigInterface $config): array
+    {
+        // Custom loading logic
+    }
+    
+    public function allowedSections(): array
+    {
+        return ['documents', 'variables'];
+    }
+}
+```
+
+### 2. Custom Source Configurations
+
+Create a new source configuration by implementing `SourceConfigInterface`:
+
+```php
+final class CustomSourceConfig implements SourceConfigInterface
+{
+    public function __construct(
+        private readonly string $customPath,
+        private readonly array $options = [],
+    ) {}
+    
+    public function getPath(): string
+    {
+        return $this->customPath;
+    }
+    
+    public function getType(): string
+    {
+        return 'custom';
+    }
+    
+    // Add custom methods as needed
+}
+```
+
+### 3. Custom Path Prefixers
+
+Create a new path prefixer by extending `PathPrefixer`:
+
+```php
+final readonly class CustomPathPrefixer extends PathPrefixer
+{
+    public function applyPrefix(array $config, string $pathPrefix): array
+    {
+        // Custom prefix application logic
+        return $config;
+    }
+}
+```
+
+## 9. Troubleshooting
+
+### Common Issues and Solutions
+
+#### 1. Circular Import Detection
+
+**Problem**: Error about circular imports detected.
+
+**Solution**: Check your import structure for cycles:
+
+- A imports B, B imports C, C imports A
+- Use simpler import hierarchies
+
+#### 2. File Not Found Errors
+
+**Problem**: Imported files cannot be found.
+
+**Solutions**:
+
+- Check if paths are relative to the correct base directory
+- Verify file permissions
+- For wildcards, check if any matching files exist
+
+#### 3. Network Issues with URL Imports
+
+**Problem**: Unable to fetch from URL.
+
+**Solutions**:
+
+- Check network connectivity
+- Verify URL is accessible and returns valid JSON/YAML
+- Check authentication headers if required
+
+#### 4. Unexpected Configuration Results
+
+**Problem**: Final configuration doesn't match expectations.
+
+**Solutions**:
+
+- Check import order (later imports override earlier ones)
+- Verify that all imports are processed successfully
+- Look for merge conflicts in imported configurations
+
+#### 5. Wildcard Path Issues
+
+**Problem**: Wildcard patterns not matching expected files.
+
+**Solutions**:
+
+- Check pattern syntax
+- Use `**` for recursive directory matching
+- Check if files have the correct extensions
+
+## 10. Implementation Notes
+
+### Performance Considerations
+
+1. **Caching**: URL imports are cached based on their TTL to avoid repeated network requests.
+
+2. **Processed Imports Tracking**: The system tracks processed imports to avoid processing the same file multiple times.
+
+3. **Selective Loading**: The system allows loading only specific parts of imported configurations.
+
+### Security Considerations
+
+1. **Local File Access**: Local imports are restricted to files within the project directory structure.
+
+2. **URL Validation**: URL imports should be restricted to trusted domains in production environments.
+
+3. **Variable Expansion**: Sensitive data like API tokens can be provided through environment variables rather than
+   hardcoded in configuration.

--- a/docs/config/readers-and-parsers-guide.md
+++ b/docs/config/readers-and-parsers-guide.md
@@ -1,0 +1,581 @@
+# Readers and Parsers Guide
+
+## 1. Overview
+
+The Readers and Parsers system forms the foundation of the configuration loading process, enabling the application to
+read configuration from various file formats and parse them into structured data. Readers handle the reading and initial
+parsing of configuration files, while Parsers process the parsed data through a plugin-based architecture to transform
+and enhance the configuration.
+
+## 2. Purpose and Use Cases
+
+The Readers and Parsers system serves several key purposes:
+
+- **Format Support**: Read configuration from different file formats (JSON, YAML, PHP)
+- **Extensible Parsing**: Process configuration through a plugin pipeline
+- **Standardization**: Convert varying input formats into a standardized internal representation
+- **Data Transformation**: Enhance raw configuration with additional processing (variables, imports)
+
+**Common Use Cases:**
+
+- Loading and parsing configuration files in different formats
+- Processing configuration with specialized plugins for features like imports and variables
+- Transforming raw configuration into structured registries for use in the application
+
+## 3. Components Breakdown
+
+### 3.1 Reader Components
+
+#### `ReaderInterface`
+
+The core interface for all configuration readers:
+
+```php
+interface ReaderInterface
+{
+    public function read(string $path): array;
+    public function supports(string $path): bool;
+    public function getSupportedExtensions(): array;
+}
+```
+
+#### `AbstractReader`
+
+Base implementation with common functionality:
+
+```php
+abstract readonly class AbstractReader implements ReaderInterface
+{
+    public function __construct(
+        protected FilesInterface $files,
+        protected ?LoggerInterface $logger = null,
+    ) {}
+    
+    public function read(string $path): array;
+    public function supports(string $path): bool;
+    abstract protected function parseContent(string $content): array;
+}
+```
+
+#### Available Readers
+
+- `JsonReader` - Reads and parses JSON files
+- `YamlReader` - Reads and parses YAML files
+- `PhpReader` - Reads PHP files that return arrays or RegistryInterface instances
+- `StringJsonReader` - Reads JSON from a string (used for inline configurations)
+
+#### `ConfigReaderRegistry`
+
+Registry for accessing readers by file extension:
+
+```php
+final readonly class ConfigReaderRegistry
+{
+    public function __construct(
+        private array $readers,
+    ) {}
+    
+    public function has(string $ext): bool;
+    public function get(string $ext): ReaderInterface;
+}
+```
+
+### 3.2 Parser Components
+
+#### `ConfigParserInterface`
+
+Interface for configuration parsers:
+
+```php
+interface ConfigParserInterface
+{
+    public function parse(array $config): ConfigRegistry;
+}
+```
+
+#### `ConfigParser`
+
+Main implementation that uses plugins for parsing:
+
+```php
+final readonly class ConfigParser implements ConfigParserInterface
+{
+    public function __construct(
+        private string $rootPath,
+        private ParserPluginRegistry $pluginRegistry,
+        private ?LoggerInterface $logger = null,
+    ) {}
+    
+    public function parse(array $config): ConfigRegistry;
+    private function preprocessConfig(array $config): array;
+}
+```
+
+#### `CompositeConfigParser`
+
+Combines multiple parsers:
+
+```php
+final readonly class CompositeConfigParser implements ConfigParserInterface
+{
+    private array $parsers;
+    
+    public function __construct(
+        ConfigParserInterface ...$parsers,
+    ) {}
+    
+    public function parse(array $config): ConfigRegistry;
+}
+```
+
+### 3.3 Parser Plugin System
+
+#### `ConfigParserPluginInterface`
+
+Interface for parser plugins:
+
+```php
+interface ConfigParserPluginInterface
+{
+    public function getConfigKey(): string;
+    public function updateConfig(array $config, string $rootPath): array;
+    public function parse(array $config, string $rootPath): ?RegistryInterface;
+    public function supports(array $config): bool;
+}
+```
+
+#### `ParserPluginRegistry`
+
+Registry for parser plugins:
+
+```php
+final class ParserPluginRegistry
+{
+    public function __construct(
+        private array $plugins = [],
+    ) {}
+    
+    public function register(ConfigParserPluginInterface $plugin): void;
+    public function getPlugins(): array;
+}
+```
+
+#### Core Parser Plugins
+
+- `ImportParserPlugin` - Processes `import` directives to include other configurations
+- `DocumentsParserPlugin` - Processes `documents` section to create document definitions
+- `VariablesParserPlugin` - Processes `variables` section for variable substitution
+
+## 4. Reading and Parsing Process
+
+The reading and parsing process follows these steps:
+
+1. **Reader Selection**: Based on file extension, select an appropriate reader
+2. **File Reading**: Read the file content using the selected reader
+3. **Initial Parsing**: Parse the raw content into a PHP array structure
+4. **Plugin Preprocessing**: Run the array through plugins that can update the configuration (e.g., imports)
+5. **Plugin Parsing**: Process the updated configuration with plugins that generate registries
+6. **Registry Collection**: Collect all registries into a ConfigRegistry
+
+## 5. Configuration Formats
+
+The system supports multiple configuration formats:
+
+### 5.1 JSON Format
+
+```json
+{
+  "variables": {
+    "VERSION": "1.0",
+    "BASE_PATH": "/docs"
+  },
+  "import": [
+    {
+      "path": "other-config.json"
+    }
+  ],
+  "documents": [
+    {
+      "description": "API Documentation",
+      "outputPath": "${BASE_PATH}/api.md",
+      "sources": [
+        {
+          "type": "file",
+          "sourcePaths": [
+            "src/Api"
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 5.2 YAML Format
+
+```yaml
+variables:
+  VERSION: 1.0
+  BASE_PATH: /docs
+
+import:
+  - path: other-config.yaml
+
+documents:
+  - description: API Documentation
+    outputPath: ${BASE_PATH}/api.md
+    sources:
+      - type: file
+        sourcePaths:
+          - src/Api
+```
+
+### 5.3 PHP Format
+
+```php
+<?php
+
+return [
+    'variables' => [
+        'VERSION' => '1.0',
+        'BASE_PATH' => '/docs',
+    ],
+    'import' => [
+        [
+            'path' => 'other-config.php',
+        ],
+    ],
+    'documents' => [
+        [
+            'description' => 'API Documentation',
+            'outputPath' => '${BASE_PATH}/api.md',
+            'sources' => [
+                [
+                    'type' => 'file',
+                    'sourcePaths' => ['src/Api'],
+                ],
+            ],
+        ],
+    ],
+];
+```
+
+## 6. Usage Examples
+
+### 6.1 Reading Configuration Files
+
+```php
+// Get reader registry
+$readerRegistry = $container->get(ConfigReaderRegistry::class);
+
+// Get reader for a specific file extension
+$reader = $readerRegistry->get('json');
+
+// Check if file is supported
+if ($reader->supports('config.json')) {
+    // Read and parse the file
+    $config = $reader->read('config.json');
+}
+```
+
+### 6.2 Parsing Configuration
+
+```php
+// Create a parser
+$parser = new ConfigParser(
+    rootPath: '/path/to/root',
+    pluginRegistry: $container->get(ParserPluginRegistry::class),
+    logger: $container->get(LoggerInterface::class)
+);
+
+// Parse configuration
+$configRegistry = $parser->parse($config);
+
+// Access specific registries
+if ($configRegistry->has('documents')) {
+    $documentRegistry = $configRegistry->get('documents', DocumentRegistry::class);
+    $documents = $documentRegistry->getItems();
+}
+```
+
+### 6.3 Using the ConfigLoader
+
+```php
+// Get config loader
+$loader = $container->get(ConfigLoaderInterface::class);
+
+// Load configuration
+try {
+    $registry = $loader->load();
+    
+    // Process the registry
+    $documents = $registry->getItems();
+    
+    foreach ($documents as $document) {
+        // Process each document
+    }
+} catch (ConfigLoaderException $e) {
+    // Handle loading error
+}
+```
+
+### 6.4 Creating a Custom Parser Plugin
+
+```php
+final readonly class CustomParserPlugin implements ConfigParserPluginInterface
+{
+    public function getConfigKey(): string
+    {
+        return 'custom';
+    }
+    
+    public function supports(array $config): bool
+    {
+        return isset($config['custom']) && is_array($config['custom']);
+    }
+    
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // Optional preprocessing logic
+        return $config;
+    }
+    
+    public function parse(array $config, string $rootPath): ?RegistryInterface
+    {
+        if (!$this->supports($config)) {
+            return null;
+        }
+        
+        // Parse the custom section
+        $customConfig = $config['custom'];
+        
+        // Create and return a registry
+        $registry = new CustomRegistry();
+        
+        // Process the custom configuration
+        
+        return $registry;
+    }
+}
+```
+
+## 7. Architecture Diagram
+
+```
+┌─────────────────┐
+│Configuration File│
+└────────┬────────┘
+         │
+         ▼
+┌────────────────┐    ┌───────────────────┐
+│ConfigReaderRegistry│─▶│Reader (JSON/YAML/PHP)│
+└────────────────┘    └─────────┬─────────┘
+                                │
+                                ▼
+                      ┌───────────────────┐
+                      │Initial PHP Array   │
+                      └─────────┬─────────┘
+                                │
+                                ▼
+┌────────────────┐    ┌───────────────────┐
+│ParserPluginRegistry│◀─┤ConfigParser       │
+└────────┬───────┘    └───────────────────┘
+         │
+         ▼
+┌────────────────┐
+│Parser Plugins   │
+│                │
+│1. ImportParser │
+│2. VariablesParser│
+│3. DocumentsParser│
+│4. Custom Plugins│
+└────────┬───────┘
+         │
+         ▼
+┌───────────────────┐
+│ConfigRegistry     │
+│(with parsed data) │
+└───────────────────┘
+```
+
+## 8. Best Practices
+
+### 1. Choose the Right Format
+
+- **JSON**: Good for machine-readable configs and integration with other systems
+- **YAML**: Better for human-edited configs with comments and less syntax overhead
+- **PHP**: Useful for dynamic configurations or when PHP logic is needed
+
+### 2. Organize Parser Plugins
+
+- Register plugins in the right order (preprocessing first, then content parsers)
+- Use dependency injection to provide plugins with needed services
+- Design plugins to be independent and focused on a single responsibility
+
+### 3. Error Handling
+
+- Wrap parsing operations in try-catch blocks to handle format errors
+- Provide detailed error messages about where parsing failed
+- Log parsing errors with context information
+
+### 4. Extension and Customization
+
+- Create custom readers for specialized formats
+- Implement parser plugins for domain-specific configuration sections
+- Use the composite parser pattern for complex parsing pipelines
+
+### 5. Performance Considerations
+
+- Cache parsed configurations when appropriate
+- Use lazy loading for expensive operations
+- Consider the overhead of parsing complex formats (YAML is slower than JSON)
+
+## 9. Extension Points
+
+### 1. Custom Readers
+
+Create a custom reader by implementing `ReaderInterface`:
+
+```php
+final readonly class CustomFormatReader implements ReaderInterface
+{
+    public function __construct(
+        private FilesInterface $files,
+        private ?LoggerInterface $logger = null,
+    ) {}
+    
+    public function read(string $path): array
+    {
+        // Read and parse the custom format
+        return [/* parsed data */];
+    }
+    
+    public function supports(string $path): bool
+    {
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        return $extension === 'custom';
+    }
+    
+    public function getSupportedExtensions(): array
+    {
+        return ['custom'];
+    }
+}
+```
+
+### 2. Custom Parser Plugins
+
+Create a custom parser plugin by implementing `ConfigParserPluginInterface`:
+
+```php
+final readonly class CustomConfigPlugin implements ConfigParserPluginInterface
+{
+    public function getConfigKey(): string
+    {
+        return 'custom_section';
+    }
+    
+    public function supports(array $config): bool
+    {
+        return isset($config['custom_section']);
+    }
+    
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // Preprocessing logic
+        return $config;
+    }
+    
+    public function parse(array $config, string $rootPath): ?RegistryInterface
+    {
+        // Parsing logic
+        return new CustomRegistry(/* parsed data */);
+    }
+}
+```
+
+### 3. Custom Registries
+
+Create a custom registry by implementing `RegistryInterface`:
+
+```php
+final class CustomRegistry implements RegistryInterface
+{
+    private array $items = [];
+    
+    public function add($item): self
+    {
+        $this->items[] = $item;
+        return $this;
+    }
+    
+    public function getType(): string
+    {
+        return 'custom_items';
+    }
+    
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+    
+    public function jsonSerialize(): array
+    {
+        return $this->items;
+    }
+}
+```
+
+## 10. Troubleshooting
+
+### Common Issues
+
+#### 1. Parse Errors in Configuration Files
+
+**Problem**: Reader fails to parse a configuration file.
+
+**Solutions**:
+
+- Check file syntax (JSON/YAML validation)
+- Verify file encoding (use UTF-8)
+- Look for special characters that might cause parsing issues
+
+#### 2. Plugin Not Processing a Section
+
+**Problem**: A parser plugin doesn't process its expected section.
+
+**Solutions**:
+
+- Verify the section exists in the config
+- Check if plugin's `supports()` method returns true
+- Ensure plugin is registered in the right order
+
+#### 3. Missing Imported Configurations
+
+**Problem**: Imported configurations are not included.
+
+**Solutions**:
+
+- Check import paths (relative vs. absolute)
+- Verify file permissions and existence
+- Look for circular import issues
+
+#### 4. Variables Not Resolved
+
+**Problem**: Variables in the configuration are not replaced with their values.
+
+**Solutions**:
+
+- Check variable syntax (${VAR_NAME})
+- Verify variables are defined in the configuration
+- Ensure VariablesParserPlugin is registered and running
+
+#### 5. Registry Type Mismatches
+
+**Problem**: Getting a registry with an unexpected type.
+
+**Solutions**:
+
+- Check if the registry exists in the ConfigRegistry
+- Verify the expected class type matches the actual registry type
+- Look for plugin parsing issues that might create wrong registry types

--- a/docs/document-compilation-guide.md
+++ b/docs/document-compilation-guide.md
@@ -1,0 +1,488 @@
+# Document Compilation Guide
+
+## 1. Overview
+
+The Document Compilation System is a component responsible for transforming configuration-defined documents into actual
+output files. It processes document definitions, collects content from various sources, applies modifiers, and produces
+compiled documents with proper formatting and structure.
+
+## 2. Purpose and Use Cases
+
+The Document Compilation System serves several key purposes:
+
+- **Generate Documentation**: Create markdown, text, or other documentation formats
+- **Aggregate Content**: Collect content from multiple sources into a single document
+- **Transform Content**: Apply modifications and formatting to source content
+- **Organize Documentation**: Structure documentation with consistent formatting and organization
+
+**Common Use Cases:**
+
+- Generating API documentation from source code
+- Creating technical specifications from multiple input files
+- Building knowledge bases from scattered content sources
+- Producing user manuals with consistent formatting and organization
+
+## 3. Components Breakdown
+
+### 3.1 Document Definition
+
+#### `Document` Class
+
+The central entity representing a document to be compiled:
+
+```php
+final class Document implements \JsonSerializable
+{
+    public function __construct(
+        public readonly string $description,
+        public readonly string $outputPath,
+        public readonly bool $overwrite = true,
+        private array $modifiers = [],
+        private array $tags = [],
+        SourceInterface ...$sources,
+    ) {}
+    
+    // Methods for managing sources, modifiers, and tags
+    public function addSource(SourceInterface ...$sources): self;
+    public function addModifier(Modifier ...$modifiers): self;
+    public function addTag(string ...$tags): self;
+    // Getter methods
+}
+```
+
+#### `DocumentRegistry` Class
+
+A collection of document definitions:
+
+```php
+final class DocumentRegistry implements RegistryInterface
+{
+    private array $documents = [];
+    
+    public function register(Document $document): self;
+    public function getItems(): array;
+    // RegistryInterface implementation
+}
+```
+
+### 3.2 Document Compilation Process
+
+#### `DocumentCompiler` Class
+
+Responsible for compiling documents:
+
+```php
+final readonly class DocumentCompiler
+{
+    public function __construct(
+        private FilesInterface $files,
+        private SourceParserInterface $parser,
+        private string $basePath,
+        private SourceModifierRegistry $modifierRegistry,
+        private VariableResolver $variables,
+        private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
+        private ?LoggerInterface $logger = null,
+    ) {}
+    
+    public function compile(Document $document): CompiledDocument;
+    public function buildContent(ErrorCollection $errors, Document $document): CompiledDocument;
+}
+```
+
+#### `CompiledDocument` Class
+
+Represents the result of compilation:
+
+```php
+final readonly class CompiledDocument
+{
+    public function __construct(
+        public string|\Stringable $content,
+        public ErrorCollection $errors,
+    ) {}
+}
+```
+
+### 3.3 Error Handling
+
+#### `ErrorCollection` Class
+
+Collects errors during compilation:
+
+```php
+final class ErrorCollection implements \Countable, \IteratorAggregate
+{
+    private array $errors = [];
+    
+    public function add(\Stringable|string $error): void;
+    public function hasErrors(): bool;
+    public function count(): int;
+    public function getIterator(): \Traversable;
+}
+```
+
+#### `SourceError` Class
+
+Represents an error from a specific source:
+
+```php
+final readonly class SourceError implements \Stringable
+{
+    public function __construct(
+        public SourceInterface $source,
+        public \Throwable $exception,
+    ) {}
+    
+    public function getSourceDescription(): string;
+    public function __toString(): string;
+}
+```
+
+### 3.4 Document Parsing
+
+#### `DocumentsParserPlugin` Class
+
+Plugin for parsing document definitions from configuration:
+
+```php
+final readonly class DocumentsParserPlugin implements ConfigParserPluginInterface
+{
+    public function __construct(
+        private SourceProviderInterface $sources,
+        private ModifierResolver $modifierResolver = new ModifierResolver(),
+        private ?LoggerInterface $logger = null,
+    ) {}
+    
+    // Implementation methods for config parsing
+}
+```
+
+## 4. Document Configuration Structure
+
+A document definition in configuration follows this structure:
+
+```yaml
+documents:
+  - description: "API Documentation"
+    outputPath: "docs/api.md"
+    overwrite: true    # Optional, default: true
+    tags: # Optional tags for categorization
+      - api
+      - reference
+    modifiers: # Optional modifiers to apply to all sources
+      - type: trim
+      - type: replace
+        search: "oldText"
+        replace: "newText"
+    sources: # Content sources
+      - type: file
+        sourcePaths:
+          - "src/Api"
+          - "src/Controllers"
+        # Source-specific options...
+
+      - type: markdown
+        content: |
+          # Additional Content
+          This is custom markdown content.
+```
+
+## 5. Compilation Process
+
+The document compilation process follows these steps:
+
+1. **Document Validation**: Verify the document has required fields (description, outputPath)
+2. **Output Path Resolution**: Resolve variables in the output path
+3. **Overwrite Check**: If `overwrite` is false and the file exists, skip compilation
+4. **Content Building**: Build document content from all sources
+    - Add document title (from description)
+    - Add document tags if present
+    - Process each source:
+        - Add source description if present
+        - Parse source content
+        - Apply modifiers (source-specific and document-level)
+        - Add content to the builder
+5. **Error Collection**: Collect any errors that occur during compilation
+6. **Directory Creation**: Ensure the output directory exists
+7. **File Writing**: Write the compiled content to the output file
+
+## 6. Usage Examples
+
+### Basic Document Definition
+
+```php
+// Create a document
+$document = Document::create(
+    description: 'API Documentation',
+    outputPath: 'docs/api.md',
+    overwrite: true,
+    tags: ['api', 'reference']
+);
+
+// Add sources
+$document->addSource(
+    new FileSource([
+        'sourcePaths' => ['src/Api', 'src/Controllers'],
+        'description' => 'API Source Files'
+    ])
+);
+
+// Add modifiers
+$document->addModifier(
+    new TrimModifier(),
+    new ReplaceModifier(['search' => '...', 'replace' => '...'])
+);
+
+// Compile the document
+$compiler = new DocumentCompiler(/* dependencies */);
+$result = $compiler->compile($document);
+
+// Check for errors
+if ($result->errors->hasErrors()) {
+    foreach ($result->errors as $error) {
+        echo "Error: $error\n";
+    }
+}
+```
+
+### Configuration-Based Compilation
+
+```php
+// Load document registry from configuration
+$configLoader = $container->get(ConfigLoaderInterface::class);
+$registry = $configLoader->load();
+
+// Get document compiler
+$compiler = $container->get(DocumentCompiler::class);
+
+// Compile all documents
+foreach ($registry->getItems() as $document) {
+    try {
+        $result = $compiler->compile($document);
+        
+        if ($result->errors->hasErrors()) {
+            // Handle errors
+        }
+    } catch (\Throwable $e) {
+        // Handle compilation failure
+    }
+}
+```
+
+## 7. Architecture Diagram
+
+```
+┌───────────────────┐
+│ConfigurationSystem│
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐    ┌───────────────────┐
+│DocumentsParserPlugin│──▶│DocumentRegistry   │
+└────────┬──────────┘    └────────┬──────────┘
+         │                        │
+         │                        │
+         ▼                        ▼
+┌───────────────────┐    ┌───────────────────┐
+│SourceProvider     │    │DocumentCompiler   │
+└────────┬──────────┘    └────────┬──────────┘
+         │                        │
+         │                        │
+         ▼                        ▼
+┌───────────────────┐    ┌───────────────────┐    ┌───────────────────┐
+│Source (File/URL/..)│──▶│ContentBuilder     │──▶│CompiledDocument   │
+└───────────────────┘    └───────────────────┘    └───────────────────┘
+         │                        ▲
+         │                        │
+         ▼                        │
+┌───────────────────┐    ┌───────────────────┐
+│SourceParser       │──▶│ModifiersApplier   │
+└───────────────────┘    └───────────────────┘
+```
+
+## 8. Best Practices
+
+### 1. Organize Document Sources
+
+- Group related sources in a single document
+- Use clear source descriptions to identify content origins
+- Order sources logically for coherent document flow
+
+### 2. Use Document Tags
+
+- Apply consistent tags for better organization
+- Use tags for categorization and filtering
+- Consider hierarchical tag structures for complex documentation
+
+### 3. Apply Appropriate Modifiers
+
+- Use document-level modifiers for global formatting
+- Apply source-specific modifiers for targeted transformations
+- Combine modifiers to achieve complex transformations
+
+### 4. Handle Errors Gracefully
+
+- Check for compilation errors
+- Provide meaningful error messages
+- Consider fallback options for critical documents
+
+### 5. Structure Output Paths
+
+- Organize output paths logically
+- Use variables for dynamic path components
+- Ensure path directories exist
+
+### 6. Logging and Debugging
+
+- Enable logging for complex compilations
+- Log each step of the compilation process
+- Include source information in error messages
+
+## 9. Extension Points
+
+The Document Compilation System can be extended in several ways:
+
+### 1. Custom Sources
+
+Create new sources by implementing `SourceInterface`:
+
+```php
+final class CustomSource implements SourceInterface
+{
+    private array $config;
+    
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+    
+    public function parseContent(
+        SourceParserInterface $parser, 
+        ModifiersApplier $modifiers
+    ): string
+    {
+        // Custom content generation logic
+        $content = // ...
+        
+        // Apply modifiers to the content
+        return $modifiers->apply($content);
+    }
+    
+    // Implement other interface methods
+}
+```
+
+### 2. Custom Modifiers
+
+Create new modifiers by implementing the `Modifier` interface:
+
+```php
+final class CustomModifier implements Modifier
+{
+    private array $config;
+    
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
+    
+    public function apply(string $content): string
+    {
+        // Custom modification logic
+        return // transformed content
+    }
+    
+    // Implement other interface methods
+}
+```
+
+### 3. Custom Content Builders
+
+Extend the content building process:
+
+```php
+final class CustomContentBuilder extends ContentBuilder
+{
+    // Override or add methods to customize content building
+    public function addCustomBlock(string $content): self
+    {
+        // Custom block handling
+        return $this;
+    }
+}
+```
+
+## 10. Troubleshooting
+
+### Common Issues
+
+#### 1. Output File Not Created
+
+**Problem**: Document compilation completes but no output file is created.
+
+**Solutions**:
+
+- Check file permissions on the output directory
+- Verify the output path is valid and resolved correctly
+- Ensure the `overwrite` flag is true if the file already exists
+
+#### 2. Missing or Empty Content
+
+**Problem**: Compiled document exists but has missing or empty content.
+
+**Solutions**:
+
+- Check if source paths exist and contain content
+- Verify that sources are correctly configured
+- Look for errors in source parsing
+- Check if modifiers are removing too much content
+
+#### 3. Formatting Issues
+
+**Problem**: Content is not formatted as expected.
+
+**Solutions**:
+
+- Review modifier ordering (they are applied in sequence)
+- Check for source-specific formatting issues
+- Verify content builder is working correctly
+
+#### 4. Variable Resolution Failures
+
+**Problem**: Variables in paths or content are not resolved.
+
+**Solutions**:
+
+- Check variable syntax (${VARIABLE} format)
+- Verify variables are defined in the configuration
+- Check if variable resolver is properly injected
+
+#### 5. Performance Issues
+
+**Problem**: Document compilation is slow for large documents.
+
+**Solutions**:
+
+- Limit the number of sources per document
+- Use more specific source paths instead of broad directories
+- Optimize expensive modifiers
+- Consider caching mechanisms for frequently used content
+
+## 11. Implementation Notes
+
+### Performance Considerations
+
+1. **Source Loading**: Sources are loaded and processed sequentially to minimize memory usage.
+
+2. **Error Collection**: Errors are collected during compilation rather than failing immediately to allow partial
+   compilation.
+
+3. **Path Resolution**: Variables in paths are resolved before file operations to avoid unnecessary file system checks.
+
+### Extensibility
+
+1. **Plugin System**: The document parsing is implemented as a plugin to allow for different document formats.
+
+2. **Modular Components**: Each component (sources, modifiers, builders) is designed to be extended.
+
+3. **Content Building**: The content building process uses a builder pattern for flexibility and extensibility.

--- a/docs/example/config/custom-tools-example.yaml
+++ b/docs/example/config/custom-tools-example.yaml
@@ -1,0 +1,159 @@
+# Custom Tools Example Configuration
+
+# This is a sample configuration file demonstrating the custom tools feature
+
+variables:
+  ROOT_DIR: /var/www/project
+  LOG_DIR: ${ROOT_DIR}/logs
+  DB_NAME: myapp_db
+
+# Custom Tools Configuration
+tools:
+  # Code Quality Tools
+  - id: cs-fixer
+    description: 'Fix code style issues'
+    type: run
+    commands:
+      - cmd: composer
+        args: [ 'cs:fix' ]
+        workingDir: ${ROOT_DIR}
+
+  - id: phpstan
+    description: 'Run static analysis'
+    type: run
+    commands:
+      - cmd: vendor/bin/phpstan
+        args: [ 'analyse', 'src', '--level', '8' ]
+        workingDir: ${ROOT_DIR}
+
+  # Testing Tools
+  - id: run-tests
+    description: 'Run PHPUnit tests'
+    type: run
+    commands:
+      - cmd: vendor/bin/phpunit
+        args: [ '--colors=always' ]
+        workingDir: ${ROOT_DIR}
+
+  - id: test-with-coverage
+    description: 'Run tests with code coverage'
+    type: run
+    commands:
+      - cmd: vendor/bin/phpunit
+        args: [ '--colors=always', '--coverage-html', '${LOG_DIR}/coverage' ]
+        workingDir: ${ROOT_DIR}
+        env:
+          XDEBUG_MODE: coverage
+
+  # Build and Deployment
+  - id: build-assets
+    description: 'Build frontend assets'
+    type: run
+    commands:
+      - cmd: npm
+        args: [ 'install' ]
+        workingDir: ${ROOT_DIR}/frontend
+      - cmd: npm
+        args: [ 'run', 'build' ]
+        workingDir: ${ROOT_DIR}/frontend
+
+  # Multi-step Process
+  - id: prepare-release
+    description: 'Prepare project for release'
+    type: run
+    commands:
+      - cmd: composer
+        args: [ 'install', '--no-dev', '--optimize-autoloader' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: npm
+        args: [ 'install', '--production' ]
+        workingDir: ${ROOT_DIR}/frontend
+      - cmd: npm
+        args: [ 'run', 'build' ]
+        workingDir: ${ROOT_DIR}/frontend
+      - cmd: php
+        args: [ 'artisan', 'optimize' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: php
+        args: [ 'artisan', 'config:cache' ]
+        workingDir: ${ROOT_DIR}
+
+  # Script Execution
+  - id: clear-logs
+    description: 'Clear log files'
+    type: run
+    commands:
+      - cmd: bash
+        args: [ '-c', 'find ${LOG_DIR} -name "*.log" -type f -delete' ]
+        workingDir: ${ROOT_DIR}
+
+  # Database Backup
+  - id: backup-db
+    description: 'Backup database to SQL file'
+    type: run
+    commands:
+      - cmd: bash
+        args: [ '-c', 'mkdir -p ${ROOT_DIR}/backups' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: bash
+        args: [
+          '-c',
+          'mysqldump -u ${DB_USER} -p${DB_PASSWORD} ${DB_NAME} > ${ROOT_DIR}/backups/${DB_NAME}_$(date +%Y%m%d).sql'
+        ]
+        workingDir: ${ROOT_DIR}
+        env:
+          DB_USER: root
+          DB_PASSWORD: "${DB_ROOT_PASSWORD}"
+
+  # Application Maintenance
+  - id: maintenance-mode
+    description: 'Toggle application maintenance mode'
+    type: run
+    commands:
+      - cmd: php
+        args: [ 'artisan', 'down', '--message="System maintenance in progress. Please check back later."' ]
+        workingDir: ${ROOT_DIR}
+
+  - id: end-maintenance
+    description: 'End application maintenance mode'
+    type: run
+    commands:
+      - cmd: php
+        args: [ 'artisan', 'up' ]
+        workingDir: ${ROOT_DIR}
+
+  # Cache Management
+  - id: clear-cache
+    description: 'Clear application cache'
+    type: run
+    commands:
+      - cmd: php
+        args: [ 'artisan', 'cache:clear' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: php
+        args: [ 'artisan', 'config:clear' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: php
+        args: [ 'artisan', 'route:clear' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: php
+        args: [ 'artisan', 'view:clear' ]
+        workingDir: ${ROOT_DIR}
+
+  # Combined Project Tools
+  - id: project-health-check
+    description: 'Run comprehensive project health check'
+    type: run
+    commands:
+      - cmd: composer
+        args: [ 'validate' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: vendor/bin/phpstan
+        args: [ 'analyse', 'src', '--level', '5' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: vendor/bin/phpunit
+        args: [ '--testsuite', 'unit' ]
+        workingDir: ${ROOT_DIR}
+      - cmd: bash
+        args: [ '-c', 'php artisan migrate:status' ]
+        workingDir: ${ROOT_DIR}

--- a/docs/mcp/custom-tools.md
+++ b/docs/mcp/custom-tools.md
@@ -1,0 +1,104 @@
+# Custom Tools
+
+The Custom Tools feature allows you to define project-specific commands that can be executed directly from the
+configuration files. This enables easy integration of common development tasks, build processes, code analysis, and
+more.
+
+## Configuration Format
+
+Custom tools are defined in the `tools` section of the configuration file. Here's the basic structure:
+
+```yaml
+tools:
+   - id: tool-id                      # Unique identifier for the tool
+     description: 'Tool description'  # Human-readable description
+     env: # Optional environment variables for all commands
+        KEY1: value1
+        KEY2: value2
+     commands: # List of commands to execute
+        - cmd: executable              # Command to run
+          args: # Command arguments (array)
+             - arg1
+             - arg2
+          workingDir: path/to/dir      # Optional working directory (relative to project root)
+          env: # Optional environment variables for this command
+             KEY1: value1
+             KEY2: value2
+```
+
+## Example Use Cases
+
+### 1. Code Style Fixing
+
+```yaml
+tools:
+   - id: cs-fixer
+     description: 'Fix code style issues'
+     commands:
+        - cmd: composer
+          args: [ 'cs:fix' ]
+```
+
+### 2. Static Analysis
+
+```yaml
+tools:
+   - id: phpstan
+     description: 'Run static analysis'
+     commands:
+        - cmd: vendor/bin/phpstan
+          args: [ 'analyse', 'src', '--level', '8' ]
+```
+
+### 3. Multi-Step Processes
+
+```yaml
+tools:
+   - id: test-suite
+     description: 'Run full test suite with coverage'
+     commands:
+        - cmd: composer
+          args: [ 'install', '--no-dev' ]
+        - cmd: vendor/bin/phpunit
+          args: [ '--coverage-html', 'coverage' ]
+        - cmd: vendor/bin/infection
+          args: [ '--min-msi=80' ]
+```
+
+### 4. Deployment
+
+```yaml
+tools:
+   - id: deploy-staging
+     description: 'Deploy to staging environment'
+     commands:
+        - cmd: bash
+          args: [ 'deploy.sh', 'staging' ]
+          env:
+             DEPLOY_TOKEN: "${STAGING_TOKEN}"
+```
+
+## Security Considerations
+
+The custom tools feature includes several security measures:
+
+1. **Environment Variable Controls**:
+    - `MCP_CUSTOM_TOOLS_ENABLE`: Enable/disable the custom tools feature (default: `true`)
+    - `MCP_TOOL_MAX_RUNTIME`: Maximum runtime for a command in seconds (default: `30`)
+
+## Environment Configuration
+
+### Environment Variables
+
+| Variable                  | Description                              | Default |
+|---------------------------|------------------------------------------|---------|
+| `MCP_CUSTOM_TOOLS_ENABLE` | Enable/disable custom tools              | `true`  |
+| `MCP_TOOL_MAX_RUNTIME`    | Maximum runtime for a command in seconds | `30`    |
+
+## Best Practices
+
+1. **Keep Commands Simple**: Break complex operations into multiple commands
+2. **Use Environment Variables**: Avoid hardcoding secrets in tool configurations
+3. **Set Appropriate Timeouts**: Adjust the `max_runtime` for long-running commands
+4. **Test Thoroughly**: Test custom tools before implementing them in production
+5. **Consider Security**: Be cautious about what commands are allowed and who can execute them

--- a/json-schema.json
+++ b/json-schema.json
@@ -18,9 +18,21 @@
       "required": [
         "prompts"
       ]
+    },
+    {
+      "required": [
+        "tools"
+      ]
     }
   ],
   "properties": {
+    "tools": {
+      "type": "array",
+      "description": "List of custom tools to be registered for execution",
+      "items": {
+        "$ref": "#/definitions/tool"
+      }
+    },
     "prompts": {
       "type": "array",
       "description": "List of prompts to be registered",
@@ -172,6 +184,69 @@
     }
   },
   "definitions": {
+    "tool": {
+      "type": "object",
+      "required": [
+        "id",
+        "description",
+        "commands"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the tool"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the tool"
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variables for command executions",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "commands": {
+          "type": "array",
+          "description": "List of commands to execute",
+          "items": {
+            "$ref": "#/definitions/toolCommand"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "toolCommand": {
+      "type": "object",
+      "required": [
+        "cmd"
+      ],
+      "properties": {
+        "cmd": {
+          "type": "string",
+          "description": "Command to execute"
+        },
+        "args": {
+          "type": "array",
+          "description": "Command arguments",
+          "items": {
+            "type": "string"
+          }
+        },
+        "workingDir": {
+          "type": "string",
+          "description": "Working directory for command execution (relative to project root)"
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variables for command execution",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "prompt": {
       "type": "object",
       "required": [

--- a/src/Application/Bootloader/McpServerBootloader.php
+++ b/src/Application/Bootloader/McpServerBootloader.php
@@ -15,6 +15,7 @@ use Butschster\ContextGenerator\McpServer\Action\Resources\ListResourcesAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Context\ContextAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Context\ContextGetAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Context\ContextRequestAction;
+use Butschster\ContextGenerator\McpServer\Action\Tools\ExecuteCustomToolAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\DirectoryListAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileApplyPatchAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInfoAction;
@@ -31,6 +32,7 @@ use Butschster\ContextGenerator\McpServer\Routing\McpResponseStrategy;
 use Butschster\ContextGenerator\McpServer\Routing\RouteRegistrar;
 use Butschster\ContextGenerator\McpServer\ServerRunner;
 use Butschster\ContextGenerator\McpServer\ServerRunnerInterface;
+use Butschster\ContextGenerator\McpServer\Tool\McpToolBootloader;
 use League\Route\Router;
 use League\Route\Strategy\StrategyInterface;
 use Psr\Container\ContainerInterface;
@@ -51,6 +53,7 @@ final class McpServerBootloader extends Bootloader
     {
         return [
             HttpClientBootloader::class,
+            McpToolBootloader::class,
         ];
     }
 
@@ -71,6 +74,10 @@ final class McpServerBootloader extends Bootloader
                 ],
                 'prompt_operations' => [
                     'enable' => (bool) $env->get('MCP_PROMPT_OPERATIONS', false),
+                ],
+                'custom_tools' => [
+                    'enable' => (bool) $env->get('MCP_CUSTOM_TOOLS_ENABLE', true),
+                    'max_runtime' => (int) $env->get('MCP_TOOL_MAX_RUNTIME', 30),
                 ],
             ],
         );
@@ -164,6 +171,13 @@ final class McpServerBootloader extends Bootloader
             if ($config->isFileWriteEnabled()) {
                 $actions[] = FileWriteAction::class;
             }
+        }
+
+        if ($config->isCustomToolsEnabled()) {
+            $actions = [
+                ...$actions,
+                ExecuteCustomToolAction::class,
+            ];
         }
 
         return $actions;

--- a/src/Config/context.yaml
+++ b/src/Config/context.yaml
@@ -7,6 +7,13 @@ documents:
           - .
           - ../Document
           - ../Fetcher
-        filePattern: '*.php'
-        showTreeView: true
+          - ../Application/Bootloader/ConfigLoaderBootloader.php
+          - ../Application/Bootloader/ImportBootloader.php
+
+  - description: Configuration Parser
+    outputPath: core/config-parser.md
+    sources:
+      - type: file
+        sourcePaths:
+          - ./Parser
 

--- a/src/McpServer/Action/Tools/ExecuteCustomToolAction.php
+++ b/src/McpServer/Action/Tools/ExecuteCustomToolAction.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools;
+
+use Butschster\ContextGenerator\McpServer\Routing\Attribute\Post;
+use Butschster\ContextGenerator\McpServer\Tool\Exception\ToolExecutionException;
+use Butschster\ContextGenerator\McpServer\Tool\ToolProviderInterface;
+use Butschster\ContextGenerator\McpServer\Tool\Types\ToolHandlerInterface;
+use Mcp\Types\CallToolResult;
+use Mcp\Types\TextContent;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+
+final readonly class ExecuteCustomToolAction
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private ToolProviderInterface $toolProvider,
+        private ToolHandlerInterface $toolHandler,
+    ) {}
+
+    #[Post(path: '/tools/call/{id}', name: 'tools.execute')]
+    public function __invoke(ServerRequestInterface $request): CallToolResult
+    {
+        $this->logger->info('Executing custom tool');
+        $toolId = $request->getAttribute('id');
+
+        if (empty($toolId) || !\is_string($toolId)) {
+            $this->logger->warning('No tool ID provided');
+            return new CallToolResult(
+                content: [new TextContent(text: 'No tool ID provided')],
+                isError: true,
+            );
+        }
+
+        try {
+            // Check if the tool exists
+            if (!$this->toolProvider->has($toolId)) {
+                $this->logger->warning('Tool not found', ['id' => $toolId]);
+                return new CallToolResult(
+                    content: [new TextContent(text: \sprintf('Tool with ID "%s" not found', $toolId))],
+                    isError: true,
+                );
+            }
+
+            // Get the tool definition
+            $tool = $this->toolProvider->get($toolId);
+
+            // Check if the tool type is supported
+            if (!$this->toolHandler->supports('run')) {
+                $this->logger->warning('Unsupported tool type', [
+                    'id' => $toolId,
+                ]);
+                return new CallToolResult(
+                    content: [new TextContent(text: \sprintf('Unsupported tool type: %s', 'run'))],
+                    isError: true,
+                );
+            }
+
+            // Execute the tool
+            $result = $this->toolHandler->execute($tool);
+
+            // Format the result
+            $output = \sprintf(
+                "Executed tool: %s\n\n%s",
+                $tool->description,
+                $result['output'] ?? 'No output',
+            );
+
+            if (isset($result['commands']) && \is_array($result['commands'])) {
+                $commandsOutput = [];
+                foreach ($result['commands'] as $commandResult) {
+                    $commandsOutput[] = \sprintf(
+                        "Command: %s\nExit Code: %d\nSuccess: %s\n\n%s",
+                        $commandResult['command'],
+                        $commandResult['exitCode'],
+                        $commandResult['success'] ? 'Yes' : 'No',
+                        $commandResult['output'] ?? 'No output',
+                    );
+                }
+
+                if (!empty($commandsOutput)) {
+                    $output .= "\n\n## Command Details\n\n" . \implode("\n---\n", $commandsOutput);
+                }
+            }
+
+            return new CallToolResult(
+                content: [new TextContent(text: $output)],
+                isError: !($result['success'] ?? true),
+            );
+        } catch (ToolExecutionException $e) {
+            $this->logger->error('Tool execution failed', [
+                'id' => $toolId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return new CallToolResult(
+                content: [new TextContent(text: \sprintf('Tool execution failed: %s', $e->getMessage()))],
+                isError: true,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('Unexpected error during tool execution', [
+                'id' => $toolId,
+                'error' => $e->getMessage(),
+                'exception' => $e::class,
+            ]);
+
+            return new CallToolResult(
+                content: [new TextContent(text: \sprintf('Unexpected error: %s', $e->getMessage()))],
+                isError: true,
+            );
+        }
+    }
+}

--- a/src/McpServer/Action/Tools/ListToolsAction.php
+++ b/src/McpServer/Action/Tools/ListToolsAction.php
@@ -6,7 +6,10 @@ namespace Butschster\ContextGenerator\McpServer\Action\Tools;
 
 use Butschster\ContextGenerator\McpServer\Registry\McpItemsRegistry;
 use Butschster\ContextGenerator\McpServer\Routing\Attribute\Get;
+use Butschster\ContextGenerator\McpServer\Tool\ToolProviderInterface;
 use Mcp\Types\ListToolsResult;
+use Mcp\Types\Tool;
+use Mcp\Types\ToolInputSchema;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 
@@ -15,6 +18,7 @@ final readonly class ListToolsAction
     public function __construct(
         private LoggerInterface $logger,
         private McpItemsRegistry $registry,
+        private ToolProviderInterface $toolProvider,
     ) {}
 
     #[Get(path: '/tools/list', name: 'tools.list')]
@@ -22,6 +26,15 @@ final readonly class ListToolsAction
     {
         $this->logger->info('Listing available tools');
 
-        return new ListToolsResult($this->registry->getTools());
+        $tools = $this->registry->getTools();
+        foreach ($this->toolProvider->all() as $toolDefinition) {
+            $tools[] = new Tool(
+                name: $toolDefinition->id,
+                inputSchema: new ToolInputSchema(),
+                description: $toolDefinition->description,
+            );
+        }
+
+        return new ListToolsResult($tools);
     }
 }

--- a/src/McpServer/Attribute/Tool.php
+++ b/src/McpServer/Attribute/Tool.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\McpServer\Attribute;
 
-use Attribute;
-
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class Tool extends McpItem
 {

--- a/src/McpServer/McpConfig.php
+++ b/src/McpServer/McpConfig.php
@@ -24,6 +24,10 @@ final class McpConfig extends InjectableConfig
         'prompt_operations' => [
             'enable' => true,
         ],
+        'custom_tools' => [
+            'enable' => true,
+            'max_runtime' => 30,
+        ],
     ];
 
     public function getDocumentNameFormat(string $path, string $description, string $tags): string
@@ -63,5 +67,10 @@ final class McpConfig extends InjectableConfig
     public function isPromptOperationsEnabled(): bool
     {
         return $this->config['prompt_operations']['enable'] ?? false;
+    }
+
+    public function isCustomToolsEnabled(): bool
+    {
+        return $this->config['custom_tools']['enable'] ?? true;
     }
 }

--- a/src/McpServer/Tool/Command/CommandExecutor.php
+++ b/src/McpServer/Tool/Command/CommandExecutor.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool\Command;
+
+use Butschster\ContextGenerator\Application\FSPath;
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolCommand;
+use Butschster\ContextGenerator\McpServer\Tool\Exception\ToolExecutionException;
+use Psr\Log\LoggerInterface;
+use Spiral\Boot\EnvironmentInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * Executes commands using Symfony Process component.
+ */
+final readonly class CommandExecutor implements CommandExecutorInterface
+{
+    public function __construct(
+        private EnvironmentInterface $envs,
+        private string $projectRoot,
+        private int $timeout = 30,
+        #[LoggerPrefix(prefix: 'tool.command.executor')]
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function execute(ToolCommand $command, array $envs = []): array
+    {
+        $this->logger?->info('Executing command', [
+            'command' => $command->cmd,
+            'args' => $command->args,
+        ]);
+
+        // Determine working directory
+        $workingDir = FSPath::create($this->projectRoot);
+
+        if ($command->workingDir !== null) {
+            $workingDir = $workingDir->join($command->workingDir);
+        }
+
+        // Create the process
+        $process = new Process(
+            command: \array_merge([$command->cmd], $command->args),
+            cwd: (string) $workingDir,
+            env: \array_merge($this->envs->getAll(), $envs, $command->env),
+            timeout: $this->timeout,
+        );
+
+        try {
+            $process->run();
+
+            $output = $process->getOutput() . $process->getErrorOutput();
+            $exitCode = $process->getExitCode() ?? -1;
+
+            if ($exitCode !== 0) {
+                $this->logger?->warning('Command exited with non-zero code', [
+                    'command' => $command->cmd,
+                    'args' => $command->args,
+                    'exitCode' => $exitCode,
+                    'output' => $output,
+                ]);
+            } else {
+                $this->logger?->info('Command executed successfully', [
+                    'command' => $command->cmd,
+                    'args' => $command->args,
+                    'exitCode' => $exitCode,
+                ]);
+            }
+
+            return [
+                'output' => $output,
+                'exitCode' => $exitCode,
+            ];
+        } catch (\Throwable $e) {
+            $this->logger?->error('Command execution failed', [
+                'command' => $command->cmd,
+                'args' => $command->args,
+                'error' => $e->getMessage(),
+                'exception' => $e::class,
+            ]);
+
+            throw ToolExecutionException::fromCommand(
+                command: $command->cmd,
+                args: $command->args,
+                reason: $e->getMessage(),
+                previous: $e,
+            );
+        }
+    }
+}

--- a/src/McpServer/Tool/Command/CommandExecutorInterface.php
+++ b/src/McpServer/Tool/Command/CommandExecutorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool\Command;
+
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolCommand;
+use Butschster\ContextGenerator\McpServer\Tool\Exception\ToolExecutionException;
+
+/**
+ * Interface for command executors.
+ */
+interface CommandExecutorInterface
+{
+    /**
+     * Executes a command and returns its output.
+     *
+     * @param ToolCommand $command The command to execute
+     * @return array{output: string, exitCode: int} Command execution result containing output and exit code
+     * @throws ToolExecutionException If the command execution fails
+     */
+    public function execute(ToolCommand $command, array $envs = []): array;
+}

--- a/src/McpServer/Tool/Config/ToolCommand.php
+++ b/src/McpServer/Tool/Config/ToolCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool\Config;
+
+/**
+ * Represents a command to be executed by a tool.
+ */
+final readonly class ToolCommand implements \JsonSerializable
+{
+    /**
+     * @param string $cmd The command to execute
+     * @param array<string> $args Command arguments
+     * @param string|null $workingDir Optional working directory (relative to project root)
+     * @param array<string, string> $env Optional environment variables
+     */
+    public function __construct(
+        public string $cmd,
+        public array $args = [],
+        public ?string $workingDir = null,
+        public array $env = [],
+    ) {}
+
+    /**
+     * Creates a ToolCommand from a configuration array.
+     *
+     * @param array<string, mixed> $config The command configuration
+     * @throws \InvalidArgumentException If the configuration is invalid
+     */
+    public static function fromArray(array $config): self
+    {
+        if (!isset($config['cmd']) || !\is_string($config['cmd'])) {
+            throw new \InvalidArgumentException('Command must have a non-empty "cmd" property');
+        }
+
+        $args = [];
+        if (isset($config['args'])) {
+            if (!\is_array($config['args'])) {
+                throw new \InvalidArgumentException('Command "args" must be an array');
+            }
+
+            foreach ($config['args'] as $arg) {
+                if (!\is_string($arg)) {
+                    throw new \InvalidArgumentException('Command arguments must be strings');
+                }
+                $args[] = $arg;
+            }
+        }
+
+        $workingDir = null;
+        if (isset($config['workingDir'])) {
+            if (!\is_string($config['workingDir'])) {
+                throw new \InvalidArgumentException('Command "workingDir" must be a string');
+            }
+            $workingDir = $config['workingDir'];
+        }
+
+        $env = [];
+        if (isset($config['env']) && \is_array($config['env'])) {
+            foreach ($config['env'] as $key => $value) {
+                if (!\is_string($key) || !\is_string($value)) {
+                    throw new \InvalidArgumentException('Environment variables must be string key-value pairs');
+                }
+                $env[$key] = $value;
+            }
+        }
+
+        return new self(
+            cmd: $config['cmd'],
+            args: $args,
+            workingDir: $workingDir,
+            env: $env,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'cmd' => $this->cmd,
+            'args' => $this->args,
+            'workingDir' => $this->workingDir,
+            'env' => $this->env,
+        ], static fn($value) => $value !== null && $value !== []);
+    }
+}

--- a/src/McpServer/Tool/Config/ToolDefinition.php
+++ b/src/McpServer/Tool/Config/ToolDefinition.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool\Config;
+
+/**
+ * Represents a tool definition loaded from configuration.
+ */
+final readonly class ToolDefinition implements \JsonSerializable
+{
+    /**
+     * @param string $id Unique identifier for the tool
+     * @param string $description Human-readable description
+     * @param array<ToolCommand> $commands List of commands to execute
+     */
+    public function __construct(
+        public string $id,
+        public string $description,
+        public array $commands,
+        public array $env = [],
+    ) {}
+
+    /**
+     * Creates a ToolDefinition from a configuration array.
+     *
+     * @param array<string, mixed> $config The tool configuration
+     * @throws \InvalidArgumentException If the configuration is invalid
+     */
+    public static function fromArray(array $config): self
+    {
+        // Validate required fields
+        if (empty($config['id']) || !\is_string($config['id'])) {
+            throw new \InvalidArgumentException('Tool must have a non-empty id');
+        }
+
+        if (empty($config['description']) || !\is_string($config['description'])) {
+            throw new \InvalidArgumentException('Tool must have a non-empty description');
+        }
+
+        // Validate and parse commands
+        $commands = [];
+        if (!isset($config['commands']) || !\is_array($config['commands'])) {
+            throw new \InvalidArgumentException('Tool must have a non-empty commands array');
+        }
+
+        foreach ($config['commands'] as $index => $commandConfig) {
+            if (!\is_array($commandConfig)) {
+                throw new \InvalidArgumentException(
+                    \sprintf('Command at index %d must be an array', $index),
+                );
+            }
+
+            try {
+                $commands[] = ToolCommand::fromArray($commandConfig);
+            } catch (\InvalidArgumentException $e) {
+                throw new \InvalidArgumentException(
+                    \sprintf('Invalid command at index %d: %s', $index, $e->getMessage()),
+                    previous: $e,
+                );
+            }
+        }
+
+        $env = [];
+        if (isset($config['env']) && \is_array($config['env'])) {
+            foreach ($config['env'] as $key => $value) {
+                if (!\is_string($key) || !\is_string($value)) {
+                    throw new \InvalidArgumentException('Environment variables must be string key-value pairs');
+                }
+                $env[$key] = $value;
+            }
+        }
+
+        return new self(
+            id: $config['id'],
+            description: $config['description'],
+            commands: $commands,
+            env: $env,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'id' => $this->id,
+            'description' => $this->description,
+            'commands' => $this->commands,
+            'env' => $this->env,
+        ], static fn($value) => $value !== null && $value !== []);
+    }
+}

--- a/src/McpServer/Tool/Exception/ToolExecutionException.php
+++ b/src/McpServer/Tool/Exception/ToolExecutionException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool\Exception;
+
+/**
+ * Exception thrown when a tool execution fails.
+ */
+final class ToolExecutionException extends \RuntimeException
+{
+    /**
+     * Creates a new tool execution exception with command details.
+     */
+    public static function fromCommand(
+        string $command,
+        array $args = [],
+        string $reason = '',
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ): self {
+        $commandStr = $command . ' ' . \implode(' ', $args);
+        $message = \sprintf('Failed to execute command: %s', $commandStr);
+
+        if ($reason !== '') {
+            $message .= \sprintf('. Reason: %s', $reason);
+        }
+
+        return new self($message, $code, $previous);
+    }
+}

--- a/src/McpServer/Tool/McpToolBootloader.php
+++ b/src/McpServer/Tool/McpToolBootloader.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool;
+
+use Butschster\ContextGenerator\Application\Bootloader\ConfigLoaderBootloader;
+use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\McpServer\Tool\Command\CommandExecutor;
+use Butschster\ContextGenerator\McpServer\Tool\Command\CommandExecutorInterface;
+use Butschster\ContextGenerator\McpServer\Tool\Types\RunToolHandler;
+use Butschster\ContextGenerator\McpServer\Tool\Types\ToolHandlerInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Core\FactoryInterface;
+
+final class McpToolBootloader extends Bootloader
+{
+    #[\Override]
+    public function defineDependencies(): array
+    {
+        return [
+            ConfigLoaderBootloader::class,
+        ];
+    }
+
+    public function init(
+        ConfigLoaderBootloader $configLoader,
+        ToolParserPlugin $parserPlugin,
+    ): void {
+        $configLoader->registerParserPlugin($parserPlugin);
+    }
+
+    #[\Override]
+    public function defineSingletons(): array
+    {
+        return [
+            ToolRegistryInterface::class => ToolRegistry::class,
+            ToolProviderInterface::class => ToolRegistry::class,
+            ToolRegistry::class => ToolRegistry::class,
+            CommandExecutorInterface::class => static fn(
+                FactoryInterface $factory,
+                DirectoriesInterface $dirs,
+                EnvironmentInterface $env,
+            ) => $factory->make(CommandExecutor::class, [
+                'projectRoot' => (string) $dirs->getRootPath(),
+                'timeout' => (int) ($env->get('MCP_TOOL_MAX_RUNTIME') ?? 30),
+            ]),
+            RunToolHandler::class => static fn(
+                FactoryInterface $factory,
+                CommandExecutorInterface $commandExecutor,
+                EnvironmentInterface $env,
+            ) => $factory->make(RunToolHandler::class, [
+                'executionEnabled' => (bool) ($env->get('MCP_TOOL_COMMAND_EXECUTION') ?? true),
+            ]),
+            ToolHandlerInterface::class => RunToolHandler::class,
+        ];
+    }
+}

--- a/src/McpServer/Tool/ToolParserPlugin.php
+++ b/src/McpServer/Tool/ToolParserPlugin.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool;
+
+use Butschster\ContextGenerator\Config\Parser\ConfigParserPluginInterface;
+use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolDefinition;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Plugin for parsing 'tools' section in configuration files.
+ */
+final readonly class ToolParserPlugin implements ConfigParserPluginInterface
+{
+    public function __construct(
+        private ToolRegistryInterface $toolRegistry,
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function getConfigKey(): string
+    {
+        return 'tools';
+    }
+
+    public function parse(array $config, string $rootPath): ?RegistryInterface
+    {
+        \assert($this->toolRegistry instanceof RegistryInterface);
+
+        if (!$this->supports($config)) {
+            return null;
+        }
+
+        $this->logger?->debug('Parsing tools configuration', [
+            'count' => \count($config['tools']),
+        ]);
+
+        foreach ($config['tools'] as $index => $toolConfig) {
+            try {
+                $tool = ToolDefinition::fromArray($toolConfig);
+                $this->toolRegistry->register($tool);
+
+                $this->logger?->debug('Tool parsed and registered', [
+                    'id' => $tool->id,
+                ]);
+            } catch (\Throwable $e) {
+                $this->logger?->warning('Failed to parse tool', [
+                    'index' => $index,
+                    'error' => $e->getMessage(),
+                ]);
+
+                throw new \InvalidArgumentException(
+                    \sprintf('Failed to parse tool at index %d: %s', $index, $e->getMessage()),
+                    previous: $e,
+                );
+            }
+        }
+
+        return $this->toolRegistry;
+    }
+
+    public function supports(array $config): bool
+    {
+        return isset($config['tools']) && \is_array($config['tools']);
+    }
+
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // This plugin doesn't modify the configuration
+        return $config;
+    }
+}

--- a/src/McpServer/Tool/ToolProviderInterface.php
+++ b/src/McpServer/Tool/ToolProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool;
+
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolDefinition;
+
+interface ToolProviderInterface
+{
+    /**
+     * Checks if a tool with the given ID exists.
+     */
+    public function has(string $id): bool;
+
+    /**
+     * Gets a tool by ID.
+     *
+     * @throws \InvalidArgumentException If no tool with the given ID exists
+     */
+    public function get(string $id): ToolDefinition;
+
+    /**
+     * Gets all tools.
+     *
+     * @return array<string, ToolDefinition>
+     */
+    public function all(): array;
+}

--- a/src/McpServer/Tool/ToolRegistry.php
+++ b/src/McpServer/Tool/ToolRegistry.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool;
+
+use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolDefinition;
+use Spiral\Core\Attribute\Singleton;
+
+/**
+ * Registry for storing tool definitions.
+ * @template TTool of ToolDefinition
+ * @implements RegistryInterface<TTool>
+ */
+#[Singleton]
+final class ToolRegistry implements RegistryInterface, ToolProviderInterface, ToolRegistryInterface
+{
+    /** @var array<non-empty-string, TTool> */
+    private array $tools = [];
+
+    public function register(ToolDefinition $tool): void
+    {
+        /**
+         * @psalm-suppress InvalidPropertyAssignmentValue
+         */
+        $this->tools[$tool->id] = $tool;
+    }
+
+    public function get(string $id): ToolDefinition
+    {
+        if (!$this->has($id)) {
+            throw new \InvalidArgumentException(
+                \sprintf('No tool with the ID "%s" exists', $id),
+            );
+        }
+
+        return $this->tools[$id];
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->tools[$id]);
+    }
+
+    public function all(): array
+    {
+        return $this->getItems();
+    }
+
+    /**
+     * Gets the type of the registry.
+     */
+    public function getType(): string
+    {
+        return 'tools';
+    }
+
+    /**
+     * Gets all items in the registry.
+     *
+     * @return array<TTool>
+     */
+    public function getItems(): array
+    {
+        return \array_values($this->tools);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'tools' => $this->getItems(),
+        ];
+    }
+}

--- a/src/McpServer/Tool/ToolRegistryInterface.php
+++ b/src/McpServer/Tool/ToolRegistryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool;
+
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolDefinition;
+
+interface ToolRegistryInterface
+{
+    /**
+     * Registers a tool in the registry.
+     *
+     * @throws \InvalidArgumentException If a tool with the same ID already exists
+     */
+    public function register(ToolDefinition $tool): void;
+}

--- a/src/McpServer/Tool/Types/AbstractToolHandler.php
+++ b/src/McpServer/Tool/Types/AbstractToolHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool\Types;
+
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolDefinition;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Abstract base class for tool type handlers.
+ */
+abstract readonly class AbstractToolHandler implements ToolHandlerInterface
+{
+    public function __construct(
+        protected ?LoggerInterface $logger = null,
+    ) {}
+
+    public function execute(ToolDefinition $tool): array
+    {
+        $this->logger?->info('Executing tool', [
+            'id' => $tool->id,
+        ]);
+
+        try {
+            $result = $this->doExecute($tool);
+
+            $this->logger?->info('Tool execution completed', [
+                'id' => $tool->id,
+                'success' => true,
+            ]);
+
+            return $result;
+        } catch (\Throwable $e) {
+            $this->logger?->error('Tool execution failed', [
+                'id' => $tool->id,
+                'error' => $e->getMessage(),
+                'exception' => $e::class,
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Performs the actual tool execution.
+     *
+     * @param ToolDefinition $tool The tool to execute
+     * @return array<string, mixed> Execution result
+     * @throws \Throwable If execution fails
+     */
+    abstract protected function doExecute(ToolDefinition $tool): array;
+}

--- a/src/McpServer/Tool/Types/RunToolHandler.php
+++ b/src/McpServer/Tool/Types/RunToolHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool\Types;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\McpServer\Tool\Command\CommandExecutorInterface;
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolDefinition;
+use Butschster\ContextGenerator\McpServer\Tool\Exception\ToolExecutionException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Handler for 'run' type tools that execute commands.
+ */
+#[LoggerPrefix(prefix: 'tool.run')]
+final readonly class RunToolHandler extends AbstractToolHandler
+{
+    /**
+     * @param CommandExecutorInterface $commandExecutor The command executor
+     * @param bool $executionEnabled Whether command execution is enabled
+     * @param LoggerInterface|null $logger Optional logger
+     */
+    public function __construct(
+        private CommandExecutorInterface $commandExecutor,
+        private bool $executionEnabled = true,
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct($logger);
+    }
+
+    public function supports(string $type): bool
+    {
+        return $type === 'run';
+    }
+
+    protected function doExecute(ToolDefinition $tool): array
+    {
+        if (!$this->executionEnabled) {
+            $this->logger?->warning('Command execution is disabled', [
+                'id' => $tool->id,
+            ]);
+
+            throw new ToolExecutionException(
+                'Command execution is disabled by configuration. Enable it by setting MCP_TOOL_COMMAND_EXECUTION=true',
+            );
+        }
+
+        if (empty($tool->commands)) {
+            throw new ToolExecutionException('Tool has no commands to execute');
+        }
+
+        $results = [];
+        $success = true;
+        $allOutput = '';
+
+        foreach ($tool->commands as $index => $command) {
+            $this->logger?->info('Executing command', [
+                'index' => $index,
+                'command' => $command->cmd,
+                'args' => $command->args,
+            ]);
+
+            try {
+                $result = $this->commandExecutor->execute($command, $tool->env);
+                $allOutput .= $result['output'] . PHP_EOL;
+
+                $results[] = [
+                    'command' => $command->cmd . ' ' . \implode(' ', $command->args),
+                    'output' => $result['output'],
+                    'exitCode' => $result['exitCode'],
+                    'success' => $result['exitCode'] === 0,
+                ];
+
+                if ($result['exitCode'] !== 0) {
+                    $success = false;
+                }
+            } catch (ToolExecutionException $e) {
+                $this->logger?->error('Command execution failed', [
+                    'index' => $index,
+                    'command' => $command->cmd,
+                    'error' => $e->getMessage(),
+                ]);
+
+                $results[] = [
+                    'command' => $command->cmd . ' ' . \implode(' ', $command->args),
+                    'output' => $e->getMessage(),
+                    'exitCode' => -1,
+                    'success' => false,
+                ];
+
+                $success = false;
+                break;
+            }
+        }
+
+        return [
+            'success' => $success,
+            'output' => $allOutput,
+            'commands' => $results,
+        ];
+    }
+}

--- a/src/McpServer/Tool/Types/ToolHandlerInterface.php
+++ b/src/McpServer/Tool/Types/ToolHandlerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Tool\Types;
+
+use Butschster\ContextGenerator\McpServer\Tool\Config\ToolDefinition;
+
+/**
+ * Interface for tool type handlers.
+ */
+interface ToolHandlerInterface
+{
+    /**
+     * Checks if this handler supports the given tool type.
+     */
+    public function supports(string $type): bool;
+
+    /**
+     * Executes the tool with the given definition.
+     *
+     * @return array<string, mixed> Execution result
+     * @throws \Throwable If execution fails
+     */
+    public function execute(ToolDefinition $tool): array;
+}

--- a/src/McpServer/context.yaml
+++ b/src/McpServer/context.yaml
@@ -17,6 +17,20 @@ documents:
           - ./Attribute
           - ./Registry
 
+  - description: "MCP Server Prompts"
+    outputPath: "mcp/prompts.md"
+    sources:
+      - type: file
+        sourcePaths:
+          - ./Prompt
+
+  - description: "MCP Server Tools"
+    outputPath: "mcp/tools.md"
+    sources:
+      - type: file
+        sourcePaths:
+          - ./Action/Tools
+
   - description: "MCP Server routing"
     outputPath: "mcp/routing.md"
     sources:


### PR DESCRIPTION
This PR adds support for defining and executing custom tools directly from configuration files.

### Features
- **Custom Tools Configuration**: Users can define project-specific tools in YAML/JSON config
- **Command Execution**: Support for running shell commands with arguments and environment variables
- **Multi-step Processes**: Tools can execute multiple commands in sequence

### Implementation Details
- Created `ToolRegistry` for storing tool definitions
- Implemented command executor using Symfony Process component
- Added extensible handler system for different tool types
- Integrated with configuration parser system
- Added environment variable controls for security

### Usage Example
```yaml
tools:
  - id: cs-fixer
    description: 'Fix code style issues'
    type: run
    commands:
      - cmd: composer
        args: ['cs:fix']
      - cmd: vendor/bin/phpunit
        args: ['--testsuite', 'unit']
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled tracking of documentation by including previously ignored content.
  - Introduced enhanced support for custom tools, enabling streamlined execution of project-specific commands and automated testing/code quality checks.
  
- **Documentation**
  - Added comprehensive guides covering configuration systems, import processes, readers/parsers, document compilation, and custom tools.
  - Expanded the user documentation to include new sections on server prompts and tools.

- **Chores**
  - Updated configuration schemas to support the new tools framework and refined project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->