### PR TITLE
fix: Fixed current dir with binary detection for self update

### DIFF
--- a/src/Console/MCPServerCommand.php
+++ b/src/Console/MCPServerCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Command\Command;
 
 #[AsCommand(
     name: 'server',
-    description: 'Start the context generator MCP server',
+    description: 'Start MCP server',
 )]
 final class MCPServerCommand extends BaseCommand
 {

--- a/src/Console/SelfUpdateCommand.php
+++ b/src/Console/SelfUpdateCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Console;
 
 use Butschster\ContextGenerator\Application\Application;
+use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\Lib\BinaryUpdater\BinaryUpdater;
 use Butschster\ContextGenerator\Lib\BinaryUpdater\UpdaterFactory;
 use Butschster\ContextGenerator\Lib\GithubClient\BinaryNameBuilder;
@@ -62,25 +63,27 @@ final class SelfUpdateCommand extends BaseCommand
         parent::__construct();
     }
 
-    public function __invoke(Application $app, EnvironmentInterface $env): int
+    public function __invoke(Application $app, EnvironmentInterface $env, DirectoriesInterface $dirs): int
     {
         $this->output->title('Context Generator Self Update');
-
-        $storeLocation = \trim($this->storeLocation ?: $env->get('CTX_BINARY_PATH', '/usr/local/bin'));
+        $storeLocation = \trim($this->storeLocation ?: $env->get('CTX_BINARY_PATH', (string) $dirs->getRootPath()));
         $type = \trim($this->type ?: ($app->isBinary ? 'bin' : 'phar'));
+
 
         // Check if we have a valid store location
         if (empty($storeLocation)) {
             $this->output->error(
-                'Self-update is only available when running the PHAR version of Context Generator.',
+                'Self-update is only available for the binary version of CTX.',
             );
             return Command::FAILURE;
         }
 
-        $binaryPath = \rtrim($storeLocation, '/') . '/' . $this->binaryName;
+        $binaryPath = (string) $dirs->getRootPath()->join($this->binaryName);
 
         $this->output->title($app->name);
         $this->output->text('Current version: ' . $app->version);
+        $this->output->text('Binary will be stored at: ' . $binaryPath);
+
         $this->output->section('Checking for updates...');
 
         // Create repository and get standard release manager

--- a/src/Console/SelfUpdateCommand.php
+++ b/src/Console/SelfUpdateCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Command\Command;
 
 #[AsCommand(
     name: 'self-update',
-    description: 'Update the Context Generator to the latest version',
+    description: 'Update app to the latest version',
     aliases: ['update'],
 )]
 final class SelfUpdateCommand extends BaseCommand
@@ -65,7 +65,7 @@ final class SelfUpdateCommand extends BaseCommand
 
     public function __invoke(Application $app, EnvironmentInterface $env, DirectoriesInterface $dirs): int
     {
-        $this->output->title('Context Generator Self Update');
+        $this->output->title('CTX Self Update');
         $storeLocation = \trim($this->storeLocation ?: $env->get('CTX_BINARY_PATH', (string) $dirs->getRootPath()));
         $type = \trim($this->type ?: ($app->isBinary ? 'bin' : 'phar'));
 

--- a/src/McpServer/Action/Resources/JsonSchemaResourceAction.php
+++ b/src/McpServer/Action/Resources/JsonSchemaResourceAction.php
@@ -15,8 +15,8 @@ use Psr\Log\LoggerInterface;
 use Spiral\Files\FilesInterface;
 
 #[Resource(
-    name: 'Json Schema of context generator',
-    description: 'Returns a simplified JSON schema of the context generator',
+    name: 'CTX app Json Schema',
+    description: 'Returns a simplified JSON schema of CTX',
     uri: 'ctx://json-schema',
     mimeType: 'application/json',
 )]

--- a/src/Source/Url/UrlSourceBootloader.php
+++ b/src/Source/Url/UrlSourceBootloader.php
@@ -34,7 +34,7 @@ final class UrlSourceBootloader extends Bootloader
                 HasPrefixLoggerInterface $logger,
             ): UrlSourceFetcher => $factory->make(UrlSourceFetcher::class, [
                 'defaultHeaders' => [
-                    'User-Agent' => 'Context Generator Bot',
+                    'User-Agent' => 'CTX Bot',
                     'Accept' => 'text/html,application/xhtml+xml',
                     'Accept-Language' => 'en-US,en;q=0.9',
                 ],

--- a/src/Source/Url/UrlSourceFetcher.php
+++ b/src/Source/Url/UrlSourceFetcher.php
@@ -29,7 +29,7 @@ final readonly class UrlSourceFetcher implements SourceFetcherInterface
     public function __construct(
         private HttpClientInterface $httpClient,
         private array $defaultHeaders = [
-            'User-Agent' => 'Context Generator Bot',
+            'User-Agent' => 'CTX Bot',
             'Accept' => 'text/html,application/xhtml+xml',
             'Accept-Language' => 'en-US,en;q=0.9',
         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The self-update command now clearly informs you where the updated binary will be stored.
- **Bug Fixes**
  - Enhanced error messaging now clearly indicates that self-update is available only for binary installations.
- **Improvements**
  - The MCP server command description has been simplified for clarity.
  - Updated naming and description for the JSON schema resource to better reflect its purpose.
  - The 'User-Agent' header in HTTP requests has been updated to 'CTX Bot' for improved identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->