### PR TITLE
feat: added an ability to import tools with workingDir support

### DIFF
--- a/src/Config/Import/Source/ImportedConfig.php
+++ b/src/Config/Import/Source/ImportedConfig.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Import\Source;
+
+final readonly class ImportedConfig implements \ArrayAccess
+{
+    public function __construct(
+        public array $config,
+        public string $path,
+        public bool $isLocal,
+    ) {}
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, $this->config);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->config[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \RuntimeException('Cannot set value in imported config');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \RuntimeException('Cannot unset value in imported config');
+    }
+}

--- a/src/Config/Import/Source/ImportedConfig.php
+++ b/src/Config/Import/Source/ImportedConfig.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Import\Source;
 
+/**
+ * @implements \ArrayAccess<non-empty-string, mixed>
+ */
 final readonly class ImportedConfig implements \ArrayAccess
 {
     public function __construct(

--- a/src/McpServer/Tool/Config/ToolCommand.php
+++ b/src/McpServer/Tool/Config/ToolCommand.php
@@ -28,7 +28,7 @@ final readonly class ToolCommand implements \JsonSerializable
      * @param array<string, mixed> $config The command configuration
      * @throws \InvalidArgumentException If the configuration is invalid
      */
-    public static function fromArray(array $config): self
+    public static function fromArray(array $config, ?string $workingDir = null): self
     {
         if (!isset($config['cmd']) || !\is_string($config['cmd'])) {
             throw new \InvalidArgumentException('Command must have a non-empty "cmd" property');
@@ -52,8 +52,12 @@ final readonly class ToolCommand implements \JsonSerializable
             }
         }
 
-        $workingDir = null;
-        if (isset($config['workingDir'])) {
+        if (
+            isset($config['workingDir'])
+            && $config['workingDir'] !== '.'
+            && $config['workingDir'] !== ''
+            && $config['workingDir'] !== null
+        ) {
             if (!\is_string($config['workingDir'])) {
                 throw new \InvalidArgumentException('Command "workingDir" must be a string');
             }

--- a/src/McpServer/Tool/Config/ToolDefinition.php
+++ b/src/McpServer/Tool/Config/ToolDefinition.php
@@ -55,7 +55,7 @@ final readonly class ToolDefinition implements \JsonSerializable
             }
 
             try {
-                $commands[] = ToolCommand::fromArray($commandConfig);
+                $commands[] = ToolCommand::fromArray($commandConfig, $config['workingDir'] ?? null);
             } catch (\InvalidArgumentException $e) {
                 throw new \InvalidArgumentException(
                     \sprintf('Invalid command at index %d: %s', $index, $e->getMessage()),


### PR DESCRIPTION
This PR introduces allowing tools to be imported from external YAML files. 

## Implementation Details

- Import paths can be absolute or relative to the importing configuration file
- Working directory handling:
  - If an imported tool specifies an absolute path for `workingDir`, it will be preserved
  - If an imported tool uses a relative path (`.` or empty string) or doesn't define `workingDir`, it will be automatically set to the directory from which the tool was imported

## Example Usage

```yaml
# Main configuration file
import:
  - path: /path/to/service/context.yaml

tools:
  # Local tools defined here
  - id: local-tool
    # ...
```

```yaml
# /path/to/service/context.yaml
tools:
  - id: reset
    description: Reset RoadRunner
    commands:
      - cmd: rr
        args:
          - reset
```

## Working Directory Resolution Rules

1. **Explicit working directory preserved**: If an imported tool has an explicit `workingDir` directive (not empty or `.`), this value is preserved:

```yaml
# Imported tool with explicit working directory
tools:
  - id: reset
    description: Reset RoadRunner
    commands:
      - cmd: rr
        workingDir: /path/to/specific/location
        args:
          - reset
```

2. **Relative working directory updated**: If the imported tool has a relative `workingDir` (`.` or empty string) or doesn't define one, it will be updated to the directory from which the tool was imported:

```yaml
# Before import (in /path/to/service/context.yaml)
tools:
  - id: reset
    description: Reset RoadRunner
    commands:
      - cmd: rr
        workingDir: .  # or not defined
        args:
          - reset
```

```yaml
# After import (resolved in main config)
tools:
  - id: reset
    description: Reset RoadRunner
    commands:
      - cmd: rr
        workingDir: /path/to/service  # Updated to directory where context.yaml resides
        args:
          - reset
```