### PR TITLE
Add MCP Source Type

### DIFF
--- a/json-schema.json
+++ b/json-schema.json
@@ -171,6 +171,19 @@
         "modifiers": {
           "type": "object",
           "description": "Named modifier configurations that can be referenced by alias"
+        },
+        "mcp": {
+          "type": "object",
+          "description": "Settings for MCP (Model Context Protocol) integration",
+          "properties": {
+            "servers": {
+              "type": "object",
+              "description": "Pre-defined MCP server configurations",
+              "additionalProperties": {
+                "$ref": "#/definitions/mcpServerConfig"
+              }
+            }
+          }
         }
       }
     },
@@ -425,6 +438,7 @@
             "github",
             "git_diff",
             "tree",
+            "mcp",
             "composer"
           ],
           "description": "Type of content source"
@@ -515,6 +529,18 @@
           },
           "then": {
             "$ref": "#/definitions/composerSource"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "mcp"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/mcpSource"
           }
         },
         {
@@ -1198,6 +1224,92 @@
         }
       }
     },
+    "mcpSource": {
+      "required": [
+        "server",
+        "operation"
+      ],
+      "properties": {
+        "server": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Reference to a pre-defined server in settings.mcp.servers"
+            },
+            {
+              "$ref": "#/definitions/mcpServerConfig"
+            }
+          ]
+        },
+        "operation": {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "resource.read",
+                "tool.call"
+              ],
+              "description": "Type of operation to execute on the MCP server"
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "resource.read"
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "resources"
+                ],
+                "properties": {
+                  "resources": {
+                    "type": "array",
+                    "description": "List of resource URIs to read",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "tool.call"
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the tool to call"
+                  },
+                  "arguments": {
+                    "type": "object",
+                    "description": "Arguments to pass to the tool",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     "php-content-filter": {
       "type": "object",
       "properties": {
@@ -1577,6 +1689,54 @@
           "private"
         ]
       }
+    },
+    "mcpServerConfig": {
+      "oneOf": [
+        {
+          "required": [
+            "command"
+          ],
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Command to execute to start the MCP server"
+            },
+            "args": {
+              "type": "array",
+              "description": "Command arguments",
+              "items": {
+                "type": "string"
+              }
+            },
+            "env": {
+              "type": "object",
+              "description": "Environment variables for the command",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "url"
+          ],
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "URL of the MCP server",
+              "format": "uri"
+            },
+            "headers": {
+              "type": "object",
+              "description": "HTTP headers to send with requests",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/src/Application/Bootloader/ConfigLoaderBootloader.php
+++ b/src/Application/Bootloader/ConfigLoaderBootloader.php
@@ -18,7 +18,6 @@ use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
 use Butschster\ContextGenerator\Document\DocumentsParserPlugin;
 use Butschster\ContextGenerator\Modifier\Alias\AliasesRegistry;
-use Butschster\ContextGenerator\Modifier\Alias\ModifierAliasesParserPlugin;
 use Butschster\ContextGenerator\Modifier\Alias\ModifierResolver;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Core\Attribute\Singleton;
@@ -57,22 +56,15 @@ final class ConfigLoaderBootloader extends Bootloader
         return [
             AliasesRegistry::class => AliasesRegistry::class,
             ModifierResolver::class => ModifierResolver::class,
-            ParserPluginRegistry::class => fn(ImportParserPlugin $importParserPlugin, DocumentsParserPlugin $documentsParserPlugin, ModifierAliasesParserPlugin $modifierAliasesParserPlugin) => new ParserPluginRegistry([
-                $modifierAliasesParserPlugin,
+            ParserPluginRegistry::class => fn(
+                ImportParserPlugin $importParserPlugin,
+                DocumentsParserPlugin $documentsParserPlugin,
+            ) => new ParserPluginRegistry([
+                // todo: think about priority when registering plugins
+                ...$this->parserPlugins,
                 $documentsParserPlugin,
                 $importParserPlugin,
-                ...$this->parserPlugins,
             ]),
-
-            //            ConfigurationProvider::class => static fn(
-            //                ConfigLoaderFactoryInterface $configLoaderFactory,
-            //                DirectoriesInterface $dirs,
-            //                HasPrefixLoggerInterface $logger,
-            //            ) => new ConfigurationProvider(
-            //                loaderFactory: $configLoaderFactory,
-            //                dirs: $dirs,
-            //                logger: $logger->withPrefix('config-provider'),
-            //            ),
 
             DocumentCompiler::class => static fn(
                 FactoryInterface $factory,
@@ -81,7 +73,12 @@ final class ConfigLoaderBootloader extends Bootloader
                 'basePath' => (string) $dirs->getOutputPath(),
             ]),
 
-            ConfigReaderRegistry::class => static fn(FilesInterface $files, JsonReader $jsonReader, YamlReader $yamlReader, PhpReader $phpReader) => new ConfigReaderRegistry(
+            ConfigReaderRegistry::class => static fn(
+                FilesInterface $files,
+                JsonReader $jsonReader,
+                YamlReader $yamlReader,
+                PhpReader $phpReader,
+            ) => new ConfigReaderRegistry(
                 readers: [
                     'json' => $jsonReader,
                     'yaml' => $yamlReader,

--- a/src/Application/Bootloader/ModifierBootloader.php
+++ b/src/Application/Bootloader/ModifierBootloader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Application\Bootloader;
 
+use Butschster\ContextGenerator\Modifier\Alias\ModifierAliasesParserPlugin;
 use Butschster\ContextGenerator\Modifier\SourceModifierRegistry;
 use Spiral\Boot\Bootloader\Bootloader;
 
@@ -15,5 +16,12 @@ final class ModifierBootloader extends Bootloader
         return [
             SourceModifierRegistry::class => SourceModifierRegistry::class,
         ];
+    }
+
+    public function boot(
+        ConfigLoaderBootloader $parserRegistry,
+        ModifierAliasesParserPlugin $plugin,
+    ): void {
+        $parserRegistry->registerParserPlugin($plugin);
     }
 }

--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -26,6 +26,7 @@ use Butschster\ContextGenerator\Source\Composer\ComposerSourceBootloader;
 use Butschster\ContextGenerator\Source\File\FileSourceBootloader;
 use Butschster\ContextGenerator\Source\GitDiff\GitDiffSourceBootloader;
 use Butschster\ContextGenerator\Source\Github\GithubSourceBootloader;
+use Butschster\ContextGenerator\Source\MCP\McpSourceBootloader;
 use Butschster\ContextGenerator\Source\Registry\SourceRegistryBootloader;
 use Butschster\ContextGenerator\Source\Text\TextSourceBootloader;
 use Butschster\ContextGenerator\Source\Tree\TreeSourceBootloader;
@@ -68,6 +69,7 @@ class Kernel extends AbstractKernel
             GithubSourceBootloader::class,
             GitDiffSourceBootloader::class,
             TreeSourceBootloader::class,
+            McpSourceBootloader::class,
 
             // Modifiers
             PhpContentFilterBootloader::class,

--- a/src/Source/Composer/ComposerSourceFactory.php
+++ b/src/Source/Composer/ComposerSourceFactory.php
@@ -38,7 +38,7 @@ final readonly class ComposerSourceFactory extends AbstractSourceFactory
         }
 
         return new ComposerSource(
-            composerPath: $composerPath,
+            composerPath: (string) $composerPath,
             description: $config['description'] ?? 'Composer Packages',
             packages: $config['packages'] ?? [],
             filePattern: $config['filePattern'] ?? '*.php',

--- a/src/Source/MCP/Config/McpServerParserPlugin.php
+++ b/src/Source/MCP/Config/McpServerParserPlugin.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Config;
+
+use Butschster\ContextGenerator\Config\Parser\ConfigParserPluginInterface;
+use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
+use Psr\Log\LoggerInterface;
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+
+/**
+ * Plugin for parsing the "settings.mcp.servers" section
+ */
+final readonly class McpServerParserPlugin implements ConfigParserPluginInterface
+{
+    public function __construct(
+        private ServerRegistry $serverRegistry,
+        #[LoggerPrefix(prefix: 'mcp-server-parser')]
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function getConfigKey(): string
+    {
+        return 'settings.mcp.servers';
+    }
+
+    public function supports(array $config): bool
+    {
+        return isset($config['settings']['mcp']['servers'])
+            && \is_array($config['settings']['mcp']['servers']);
+    }
+
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // By default, return the config unchanged
+        return $config;
+    }
+
+    public function parse(array $config, string $rootPath): ?RegistryInterface
+    {
+        if (!$this->supports($config)) {
+            $this->logger?->debug('No MCP server settings found in configuration');
+            return null;
+        }
+
+        $serversConfig = $config['settings']['mcp']['servers'];
+        $this->logger?->info('Parsing MCP server configurations', [
+            'serverCount' => \count($serversConfig),
+        ]);
+
+        foreach ($serversConfig as $name => $serverConfig) {
+            try {
+                $this->logger?->debug('Parsing server configuration', [
+                    'name' => $name,
+                ]);
+
+                $server = ServerConfig::fromArray($serverConfig);
+                $this->serverRegistry->register($name, $server);
+
+                $this->logger?->debug('Registered MCP server', [
+                    'name' => $name,
+                ]);
+            } catch (\Throwable $e) {
+                $this->logger?->warning("Failed to register MCP server '{$name}'", [
+                    'error' => $e->getMessage(),
+                    'config' => $serverConfig,
+                ]);
+            }
+        }
+
+        $this->logger?->info('MCP server configurations parsed successfully', [
+            'registeredServers' => \count($this->serverRegistry->all()),
+        ]);
+
+        return null;
+    }
+}

--- a/src/Source/MCP/Config/ServerConfig.php
+++ b/src/Source/MCP/Config/ServerConfig.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Config;
+
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+
+/**
+ * Configuration for an MCP server
+ */
+final readonly class ServerConfig implements \JsonSerializable
+{
+    private function __construct(
+        public ?string $command,
+        public array $args,
+        public array $env,
+        public ?string $url,
+        public array $headers,
+    ) {}
+
+    /**
+     * Create a new server configuration for a command-based server
+     */
+    public static function createForCommand(
+        string $command,
+        array $args = [],
+        array $env = [],
+    ): self {
+        return new self(
+            command: $command,
+            args: $args,
+            env: $env,
+            url: null,
+            headers: [],
+        );
+    }
+
+    /**
+     * Create a new server configuration for a URL-based server
+     *
+     * @param string $url Server URL
+     * @param array<string, string> $headers HTTP headers
+     */
+    public static function createForUrl(
+        string $url,
+        array $headers = [],
+    ): self {
+        return new self(
+            command: null,
+            args: [],
+            env: [],
+            url: $url,
+            headers: $headers,
+        );
+    }
+
+    /**
+     * Create a server configuration from an array
+     */
+    public static function fromArray(array $config): self
+    {
+        if (isset($config['url'])) {
+            return self::createForUrl(
+                url: (string) $config['url'],
+                headers: (array) ($config['headers'] ?? []),
+            );
+        }
+
+        if (isset($config['command'])) {
+            return self::createForCommand(
+                command: (string) $config['command'],
+                args: (array) ($config['args'] ?? []),
+                env: (array) ($config['env'] ?? []),
+            );
+        }
+
+        throw new \InvalidArgumentException('Server configuration must have either "url" or "command" property');
+    }
+
+    /**
+     * Apply variable resolution to this configuration
+     */
+    public function withResolvedVariables(VariableResolver $resolver): self
+    {
+        // For command-based servers
+        if ($this->command !== null) {
+            $resolvedEnv = [];
+            foreach ($this->env as $key => $value) {
+                $resolvedEnv[$key] = $resolver->resolve($value);
+            }
+
+            return new self(
+                command: $resolver->resolve($this->command),
+                args: \array_map($resolver->resolve(...), $this->args),
+                env: $resolvedEnv,
+                url: null,
+                headers: [],
+            );
+        }
+
+        // For URL-based servers
+        if ($this->url !== null) {
+            $resolvedHeaders = [];
+            foreach ($this->headers as $key => $value) {
+                $resolvedHeaders[$key] = $resolver->resolve($value);
+            }
+
+            return new self(
+                command: null,
+                args: [],
+                env: [],
+                url: $resolver->resolve($this->url),
+                headers: $resolvedHeaders,
+            );
+        }
+
+        return $this;
+    }
+
+    public function isCommandBased(): bool
+    {
+        return $this->command !== null;
+    }
+
+    public function isUrlBased(): bool
+    {
+        return $this->url !== null;
+    }
+
+    public function jsonSerialize(): array
+    {
+        if ($this->isCommandBased()) {
+            return \array_filter([
+                'command' => $this->command,
+                'args' => $this->args,
+                'env' => $this->env,
+            ]);
+        }
+
+        if ($this->isUrlBased()) {
+            return \array_filter([
+                'url' => $this->url,
+                'headers' => $this->headers,
+            ]);
+        }
+
+        return [];
+    }
+}

--- a/src/Source/MCP/Config/ServerRegistry.php
+++ b/src/Source/MCP/Config/ServerRegistry.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Config;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Registry for MCP server configurations
+ */
+final class ServerRegistry
+{
+    /** @var array<string, ServerConfig> */
+    private array $servers = [];
+
+    public function __construct(
+        #[LoggerPrefix(prefix: 'mcp-server-registry')]
+        private readonly ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Register a server configuration
+     */
+    public function register(string $name, ServerConfig $config): self
+    {
+        $this->logger?->debug('Registering MCP server', [
+            'name' => $name,
+            'config' => $config,
+        ]);
+
+        $this->servers[$name] = $config;
+
+        return $this;
+    }
+
+    /**
+     * Check if a server with the given name exists
+     */
+    public function has(string $name): bool
+    {
+        return isset($this->servers[$name]);
+    }
+
+    /**
+     * Get a server configuration by name
+     */
+    public function get(string $name): ServerConfig
+    {
+        if (!$this->has($name)) {
+            throw new \InvalidArgumentException(\sprintf('MCP server "%s" not found in registry', $name));
+        }
+
+        return $this->servers[$name];
+    }
+
+    /**
+     * Get all server configurations
+     *
+     * @return array<string, ServerConfig>
+     */
+    public function all(): array
+    {
+        return $this->servers;
+    }
+}

--- a/src/Source/MCP/Connection/ConnectionManager.php
+++ b/src/Source/MCP/Connection/ConnectionManager.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Connection;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+use Butschster\ContextGenerator\Source\MCP\Config\ServerConfig;
+use Mcp\Client\Client;
+use Mcp\Client\ClientSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Manager for MCP client connections
+ */
+final class ConnectionManager
+{
+    /** @var array<string, ClientSession> */
+    private array $sessions = [];
+
+    private ?Client $client = null;
+
+    public function __construct(
+        private readonly VariableResolver $variableResolver = new VariableResolver(),
+        #[LoggerPrefix(prefix: 'mcp-connection')]
+        private readonly ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Create or get an MCP client session for the given server configuration
+     */
+    public function getSession(ServerConfig $config): ClientSession
+    {
+        // Create a unique key for this server configuration
+        $key = $this->createConfigKey($config);
+
+        // If we already have a session for this configuration, return it
+        if (isset($this->sessions[$key])) {
+            $this->logger?->debug('Using existing MCP client session', [
+                'key' => $key,
+            ]);
+            return $this->sessions[$key];
+        }
+
+        // Otherwise, create a new session
+        $this->logger?->info('Creating new MCP client session', [
+            'key' => $key,
+            'config' => $config,
+        ]);
+
+        // Apply variable resolution
+        $resolvedConfig = $config->withResolvedVariables($this->variableResolver);
+
+        // Create the client if it doesn't exist
+        if ($this->client === null) {
+            $this->client = new Client($this->logger);
+        }
+
+        // Connect based on configuration type
+        if ($resolvedConfig->isCommandBased()) {
+            $this->logger?->debug('Connecting to command-based MCP server', [
+                'command' => $resolvedConfig->command,
+                'args' => $resolvedConfig->args,
+                'envCount' => \count($resolvedConfig->env),
+            ]);
+
+            $session = $this->client->connect(
+                commandOrUrl: $resolvedConfig->command,
+                args: $resolvedConfig->args,
+                env: $resolvedConfig->env,
+            );
+        } elseif ($resolvedConfig->isUrlBased()) {
+            $this->logger?->debug('Connecting to URL-based MCP server', [
+                'url' => $resolvedConfig->url,
+                'headersCount' => \count($resolvedConfig->headers),
+            ]);
+
+            // TODO: Implement URL-based connection with headers
+            $session = $this->client->connect($resolvedConfig->url);
+        } else {
+            throw new \InvalidArgumentException('Invalid server configuration');
+        }
+
+        // Store the session for reuse
+        $this->sessions[$key] = $session;
+
+        return $session;
+    }
+
+    /**
+     * Close all sessions and the client
+     */
+    public function close(): void
+    {
+        $this->logger?->info('Closing all MCP client sessions');
+
+        // Close each session (though the client close should handle this)
+        $this->sessions = [];
+
+        // Close the client
+        if ($this->client !== null) {
+            $this->client->close();
+            $this->client = null;
+        }
+    }
+
+    /**
+     * Create a unique key for a server configuration
+     *
+     * @param ServerConfig $config Server configuration
+     * @return string Unique key
+     */
+    private function createConfigKey(ServerConfig $config): string
+    {
+        if ($config->isCommandBased()) {
+            return 'cmd:' . \md5($config->command . \json_encode($config->args) . \json_encode($config->env));
+        }
+
+        if ($config->isUrlBased()) {
+            return 'url:' . \md5($config->url . \json_encode($config->headers));
+        }
+
+        return 'invalid:' . \spl_object_hash($config);
+    }
+}

--- a/src/Source/MCP/McpSource.php
+++ b/src/Source/MCP/McpSource.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP;
+
+use Butschster\ContextGenerator\Source\SourceWithModifiers;
+use Butschster\ContextGenerator\Source\MCP\Config\ServerConfig;
+use Butschster\ContextGenerator\Source\MCP\Operations\OperationInterface;
+
+/**
+ * Source for MCP (Model Context Protocol) server content
+ */
+final class McpSource extends SourceWithModifiers
+{
+    /**
+     * @param ServerConfig $serverConfig Server configuration
+     * @param OperationInterface $operation Operation to execute on the server
+     * @param string $description Human-readable description
+     * @param array<non-empty-string> $tags
+     * @param array<\Butschster\ContextGenerator\Modifier\Modifier> $modifiers
+     */
+    public function __construct(
+        public readonly ServerConfig $serverConfig,
+        public readonly OperationInterface $operation,
+        string $description = '',
+        array $tags = [],
+        array $modifiers = [],
+    ) {
+        parent::__construct(description: $description, tags: $tags, modifiers: $modifiers);
+    }
+
+    #[\Override]
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'type' => 'mcp',
+            ...parent::jsonSerialize(),
+            'server' => $this->serverConfig,
+            'operation' => $this->operation,
+        ], static fn($value) => $value !== null && $value !== '' && $value !== []);
+    }
+}

--- a/src/Source/MCP/McpSourceBootloader.php
+++ b/src/Source/MCP/McpSourceBootloader.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP;
+
+use Butschster\ContextGenerator\Application\Bootloader\ConfigLoaderBootloader;
+use Butschster\ContextGenerator\Application\Bootloader\SourceFetcherBootloader;
+use Butschster\ContextGenerator\Source\MCP\Config\McpServerParserPlugin;
+use Butschster\ContextGenerator\Source\Registry\SourceRegistryInterface;
+use Butschster\ContextGenerator\Source\MCP\Config\ServerRegistry;
+use Butschster\ContextGenerator\Source\MCP\Operations\OperationFactory;
+use Butschster\ContextGenerator\Source\MCP\Connection\ConnectionManager;
+use Spiral\Boot\Bootloader\Bootloader;
+
+final class McpSourceBootloader extends Bootloader
+{
+    #[\Override]
+    public function defineSingletons(): array
+    {
+        return [
+            McpSourceFetcher::class => McpSourceFetcher::class,
+            ServerRegistry::class => ServerRegistry::class,
+            OperationFactory::class => OperationFactory::class,
+            ConnectionManager::class => ConnectionManager::class,
+        ];
+    }
+
+    public function init(
+        SourceFetcherBootloader $registry,
+        SourceRegistryInterface $sourceRegistry,
+        McpSourceFactory $factory,
+    ): void {
+        $registry->register(McpSourceFetcher::class);
+        $sourceRegistry->register($factory);
+    }
+
+    public function boot(
+        ConfigLoaderBootloader $parserRegistry,
+        McpServerParserPlugin $plugin,
+    ): void {
+        $parserRegistry->registerParserPlugin($plugin);
+    }
+}

--- a/src/Source/MCP/McpSourceFactory.php
+++ b/src/Source/MCP/McpSourceFactory.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\Source\Registry\AbstractSourceFactory;
+use Butschster\ContextGenerator\Source\SourceInterface;
+use Butschster\ContextGenerator\Source\MCP\Config\ServerConfig;
+use Butschster\ContextGenerator\Source\MCP\Config\ServerRegistry;
+use Butschster\ContextGenerator\Source\MCP\Operations\OperationFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Factory for creating McpSource instances
+ */
+#[LoggerPrefix(prefix: 'mcp-source-factory')]
+final readonly class McpSourceFactory extends AbstractSourceFactory
+{
+    public function __construct(
+        private ServerRegistry $serverRegistry,
+        private OperationFactory $operationFactory,
+        DirectoriesInterface $dirs,
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct(dirs: $dirs, logger: $logger);
+    }
+
+    #[\Override]
+    public function getType(): string
+    {
+        return 'mcp';
+    }
+
+    #[\Override]
+    public function create(array $config): SourceInterface
+    {
+        $this->logger?->debug('Creating MCP source', [
+            'config' => $config,
+        ]);
+
+        if (!isset($config['server'])) {
+            throw new \RuntimeException('MCP source must have a "server" property');
+        }
+
+        if (!isset($config['operation'])) {
+            throw new \RuntimeException('MCP source must have an "operation" property');
+        }
+
+        // Get server configuration
+        $serverConfig = $this->resolveServerConfig($config['server']);
+
+        // Create operation
+        $operation = $this->operationFactory->create($config['operation']);
+
+        return new McpSource(
+            serverConfig: $serverConfig,
+            operation: $operation,
+            description: $config['description'] ?? '',
+            tags: $config['tags'] ?? [],
+            modifiers: $config['modifiers'] ?? [],
+        );
+    }
+
+    /**
+     * Resolve server configuration from config or registry
+     */
+    private function resolveServerConfig(string|array $serverConfig): ServerConfig
+    {
+        // If server is a string, look it up in the registry
+        if (\is_string($serverConfig)) {
+            if (!$this->serverRegistry->has($serverConfig)) {
+                throw new \RuntimeException(\sprintf('MCP server "%s" not found in registry', $serverConfig));
+            }
+
+            return $this->serverRegistry->get($serverConfig);
+        }
+
+        // Otherwise, create a new server config
+        return ServerConfig::fromArray($serverConfig);
+    }
+}

--- a/src/Source/MCP/McpSourceFetcher.php
+++ b/src/Source/MCP/McpSourceFetcher.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
+use Butschster\ContextGenerator\Source\Fetcher\SourceFetcherInterface;
+use Butschster\ContextGenerator\Source\SourceInterface;
+use Butschster\ContextGenerator\Source\MCP\Connection\ConnectionManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Fetcher for MCP sources
+ * @implements SourceFetcherInterface<McpSource>
+ */
+final readonly class McpSourceFetcher implements SourceFetcherInterface
+{
+    public function __construct(
+        private ConnectionManager $connectionManager,
+        private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
+        private VariableResolver $variableResolver = new VariableResolver(),
+        #[LoggerPrefix(prefix: 'mcp-source')]
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function supports(SourceInterface $source): bool
+    {
+        $isSupported = $source instanceof McpSource;
+        $this->logger?->debug('Checking if source is supported', [
+            'sourceType' => $source::class,
+            'isSupported' => $isSupported,
+        ]);
+        return $isSupported;
+    }
+
+    public function fetch(SourceInterface $source, ModifiersApplierInterface $modifiersApplier): string
+    {
+        if (!$source instanceof McpSource) {
+            $errorMessage = 'Source must be an instance of McpSource';
+            $this->logger?->error($errorMessage, [
+                'sourceType' => $source::class,
+            ]);
+            throw new \InvalidArgumentException($errorMessage);
+        }
+
+        $description = $this->variableResolver->resolve($source->getDescription());
+
+        $this->logger?->info('Fetching MCP source content', [
+            'description' => $description,
+            'server' => $source->serverConfig,
+            'operation' => $source->operation,
+        ]);
+
+        try {
+            // Get or create a client session
+            $session = $this->connectionManager->getSession($source->serverConfig);
+
+            // Execute the operation
+            $content = $source->operation->execute($session, $this->variableResolver);
+
+
+            // Create builder
+            $builder = $this->builderFactory
+                ->create()
+                ->addDescription($description);
+
+            // Build content based on operation type
+            $source->operation->buildContent($builder, $content);
+
+            // Add separator
+            $builder->addSeparator();
+
+            $result = $builder->build();
+            $this->logger?->info('MCP source content fetched successfully', [
+                'contentLength' => \strlen($result),
+            ]);
+
+            return $result;
+        } catch (\Throwable $e) {
+            $errorMessage = \sprintf('Error fetching MCP source: %s', $e->getMessage());
+            $this->logger?->error($errorMessage, [
+                'exception' => $e,
+                'server' => $source->serverConfig,
+                'operation' => $source->operation,
+            ]);
+            throw new \RuntimeException($errorMessage, 0, $e);
+        }
+    }
+}

--- a/src/Source/MCP/Operations/AbstractOperation.php
+++ b/src/Source/MCP/Operations/AbstractOperation.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Operations;
+
+use Butschster\ContextGenerator\Lib\Content\ContentBuilder;
+
+/**
+ * Abstract base class for operations
+ */
+abstract readonly class AbstractOperation implements OperationInterface
+{
+    /**
+     * @param string $type Operation type
+     */
+    public function __construct(
+        protected string $type,
+    ) {}
+
+    /**
+     * @return string Operation type
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Default implementation of buildContent
+     *
+     * @param ContentBuilder $builder Content builder to add content to
+     * @param string $content The content to be built
+     */
+    public function buildContent(ContentBuilder $builder, string $content): void
+    {
+        $builder->addText($content);
+    }
+
+    /**
+     * Default implementation of jsonSerialize
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->type,
+        ];
+    }
+}

--- a/src/Source/MCP/Operations/CallToolOperation.php
+++ b/src/Source/MCP/Operations/CallToolOperation.php
@@ -7,7 +7,6 @@ namespace Butschster\ContextGenerator\Source\MCP\Operations;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilder;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Mcp\Client\ClientSession;
-use Mcp\Types\CallToolResult;
 use Mcp\Types\TextContent;
 
 /**

--- a/src/Source/MCP/Operations/CallToolOperation.php
+++ b/src/Source/MCP/Operations/CallToolOperation.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Operations;
+
+use Butschster\ContextGenerator\Lib\Content\ContentBuilder;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+use Mcp\Client\ClientSession;
+use Mcp\Types\CallToolResult;
+use Mcp\Types\TextContent;
+
+/**
+ * Operation for calling tools on an MCP server
+ */
+final readonly class CallToolOperation extends AbstractOperation
+{
+    /**
+     * @param string $name Name of the tool to call
+     * @param array<string, mixed>|null $arguments Arguments to pass to the tool
+     */
+    public function __construct(
+        public string $name,
+        public ?array $arguments = null,
+    ) {
+        parent::__construct('tool.call');
+    }
+
+    /**
+     * Execute this operation on the given client session
+     *
+     * @param ClientSession $session MCP client session
+     * @param VariableResolver $resolver Variable resolver for resolving variables in configuration
+     * @return string Raw result of the tool call
+     */
+    public function execute(ClientSession $session, VariableResolver $resolver): string
+    {
+        // Resolve variables in tool name
+        $resolvedToolName = $resolver->resolve($this->name);
+
+        // Resolve variables in arguments
+        $resolvedArguments = null;
+        if ($this->arguments !== null) {
+            $resolvedArguments = [];
+            foreach ($this->arguments as $key => $value) {
+                if (\is_string($value)) {
+                    $resolvedArguments[$key] = $resolver->resolve($value);
+                } else {
+                    $resolvedArguments[$key] = $value;
+                }
+            }
+        }
+
+        // Call the tool
+        $result = $session->callTool($resolvedToolName, $resolvedArguments);
+
+        $content = '';
+
+        foreach ($result->content as $item) {
+            if ($item instanceof TextContent) {
+                $content .= $item->text;
+            }
+        }
+
+        return $content;
+    }
+
+    /**
+     * Build content for this operation
+     *
+     * @param ContentBuilder $builder Content builder to add content to
+     * @param string $content The processed content to build with
+     */
+    #[\Override]
+    public function buildContent(ContentBuilder $builder, string $content): void
+    {
+        // Try to parse as JSON first
+        $decoded = \json_decode($content, true);
+
+        if (\json_last_error() === JSON_ERROR_NONE && \is_array($decoded)) {
+            // It's valid JSON, so format it nicely
+            $builder->addTitle(\sprintf('Tool: %s', $this->name), 2);
+
+            if ($this->arguments !== null && !empty($this->arguments)) {
+                $builder->addTitle('Arguments:', 3);
+                $builder->addCodeBlock(\json_encode($this->arguments, JSON_PRETTY_PRINT), 'json');
+            }
+
+            $builder->addTitle('Result:', 3);
+            $builder->addCodeBlock(\json_encode($decoded, JSON_PRETTY_PRINT), 'json');
+        } else {
+            // It's not JSON, or not an array, so treat it as text
+            $builder->addTitle(\sprintf('Tool: %s', $this->name), 2);
+
+            if ($this->arguments !== null && !empty($this->arguments)) {
+                $builder->addTitle('Arguments:', 3);
+                $builder->addCodeBlock(\json_encode($this->arguments, JSON_PRETTY_PRINT), 'json');
+            }
+
+            $builder->addTitle('Result:', 3);
+            $builder->addText($content);
+        }
+    }
+
+    /**
+     * Serialize to JSON
+     */
+    #[\Override]
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            ...parent::jsonSerialize(),
+            'name' => $this->name,
+            'arguments' => $this->arguments,
+        ]);
+    }
+}

--- a/src/Source/MCP/Operations/OperationFactory.php
+++ b/src/Source/MCP/Operations/OperationFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Operations;
+
+/**
+ * Factory for creating operations
+ */
+final readonly class OperationFactory
+{
+    /**
+     * Create an operation from the given configuration
+     *
+     * @param array<string, mixed> $config Operation configuration
+     * @return OperationInterface Created operation
+     * @throws \InvalidArgumentException If the operation type is invalid or missing
+     */
+    public function create(array $config): OperationInterface
+    {
+        if (!isset($config['type'])) {
+            throw new \InvalidArgumentException('Operation configuration must have a "type" property');
+        }
+
+        $type = (string) $config['type'];
+
+        return match ($type) {
+            'resource.read' => $this->createReadResourceOperation($config),
+            'tool.call' => $this->createCallToolOperation($config),
+            default => throw new \InvalidArgumentException(\sprintf('Unknown operation type: %s', $type)),
+        };
+    }
+
+    /**
+     * Create a ReadResourceOperation
+     */
+    private function createReadResourceOperation(array $config): ReadResourceOperation
+    {
+        if (!isset($config['resources']) || !\is_array($config['resources'])) {
+            throw new \InvalidArgumentException('ReadResourceOperation must have a "resources" array property');
+        }
+
+        return new ReadResourceOperation($config['resources']);
+    }
+
+    /**
+     * Create a CallToolOperation
+     */
+    private function createCallToolOperation(array $config): CallToolOperation
+    {
+        if (!isset($config['name'])) {
+            throw new \InvalidArgumentException('CallToolOperation must have a "name" property');
+        }
+
+        return new CallToolOperation(
+            name: (string) $config['name'],
+            arguments: $config['arguments'] ?? null,
+        );
+    }
+}

--- a/src/Source/MCP/Operations/OperationInterface.php
+++ b/src/Source/MCP/Operations/OperationInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Operations;
+
+use Butschster\ContextGenerator\Lib\Content\ContentBuilder;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+use Mcp\Client\ClientSession;
+
+/**
+ * Interface for operations that can be executed on an MCP server
+ */
+interface OperationInterface extends \JsonSerializable
+{
+    /**
+     * Get the type of this operation
+     */
+    public function getType(): string;
+
+    /**
+     * Execute this operation on the given client session
+     *
+     * @param ClientSession $session MCP client session
+     * @param VariableResolver $resolver Variable resolver for resolving variables in configuration
+     * @return string Raw content returned by the operation
+     */
+    public function execute(ClientSession $session, VariableResolver $resolver): string;
+
+    /**
+     * Build content for this operation
+     *
+     * @param ContentBuilder $builder Content builder to add content to
+     * @param string $content The processed content to build with
+     */
+    public function buildContent(ContentBuilder $builder, string $content): void;
+}

--- a/src/Source/MCP/Operations/ReadResourceOperation.php
+++ b/src/Source/MCP/Operations/ReadResourceOperation.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\MCP\Operations;
+
+use Butschster\ContextGenerator\Lib\Content\ContentBuilder;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+use Mcp\Client\ClientSession;
+use Mcp\Types\TextResourceContents;
+
+/**
+ * Operation for reading resources from an MCP server
+ */
+final readonly class ReadResourceOperation extends AbstractOperation
+{
+    /**
+     * @param array<string> $resources List of resource URIs to read
+     */
+    public function __construct(
+        public array $resources = [],
+    ) {
+        parent::__construct('resource.read');
+    }
+
+    /**
+     * Execute this operation on the given client session
+     *
+     * @param ClientSession $session MCP client session
+     * @param VariableResolver $resolver Variable resolver for resolving variables in configuration
+     * @return string Raw content of all resources
+     */
+    public function execute(ClientSession $session, VariableResolver $resolver): string
+    {
+        $results = [];
+
+        // Resolve variables in all resource URIs
+        $resolvedResources = \array_map($resolver->resolve(...), $this->resources);
+
+        // Read each resource
+        foreach ($resolvedResources as $uri) {
+            $result = $session->readResource($uri);
+
+
+            foreach ($result->contents as $content) {
+                if ($content instanceof TextResourceContents) {
+                    $results[] = $content->text;
+                }
+            }
+        }
+
+        // Return JSON-encoded results for later processing
+        return \implode("\n", $results);
+    }
+
+    /**
+     * Build content for this operation
+     *
+     * @param ContentBuilder $builder Content builder to add content to
+     * @param string $content The processed content to build with
+     */
+    #[\Override]
+    public function buildContent(ContentBuilder $builder, string $content): void
+    {
+        // Add code block for this resource
+        $builder->addCodeBlock($content, 'json');
+    }
+
+    /**
+     * Serialize to JSON
+     */
+    #[\Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            ...parent::jsonSerialize(),
+            'resources' => $this->resources,
+        ];
+    }
+
+    /**
+     * Determine language from content type and URI
+     */
+    private function determineLanguageFromContentTypeAndUri(?string $contentType, string $uri): ?string
+    {
+        // If content type is set, try to determine language from it
+        if ($contentType !== null) {
+            return match (true) {
+                \str_contains($contentType, 'php') => 'php',
+                \str_contains($contentType, 'javascript') => 'javascript',
+                \str_contains($contentType, 'typescript') => 'typescript',
+                \str_contains($contentType, 'json') => 'json',
+                \str_contains($contentType, 'yaml') || \str_contains($contentType, 'yml') => 'yaml',
+                \str_contains($contentType, 'html') => 'html',
+                \str_contains($contentType, 'css') => 'css',
+                \str_contains($contentType, 'markdown') || \str_contains($contentType, 'md') => 'markdown',
+                default => null,
+            };
+        }
+
+        // Otherwise, try to determine from file extension
+        $extension = \pathinfo($uri, PATHINFO_EXTENSION);
+
+        return match ($extension) {
+            'php' => 'php',
+            'js' => 'javascript',
+            'ts' => 'typescript',
+            'json' => 'json',
+            'yaml', 'yml' => 'yaml',
+            'html', 'htm' => 'html',
+            'css' => 'css',
+            'md', 'markdown' => 'markdown',
+            default => null,
+        };
+    }
+
+    /**
+     * Extract filename from URI
+     */
+    private function extractFilenameFromUri(string $uri): string
+    {
+        // Remove scheme and authority
+        $path = \preg_replace('#^[^:]+://[^/]+#', '', $uri);
+
+        // If the URI is just a path, return it
+        if ($path === $uri) {
+            return $uri;
+        }
+
+        return $path ?: $uri;
+    }
+}

--- a/src/Source/context.yaml
+++ b/src/Source/context.yaml
@@ -50,6 +50,14 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
+  - description: Source Implementations - MCP
+    outputPath: sources/mcp-source.md
+    sources:
+      - type: file
+        sourcePaths: ./MCP
+        filePattern: '*.php'
+        showTreeView: true
+
   - description: Source Implementations - Git Diff
     outputPath: sources/git-diff-source.md
     sources:


### PR DESCRIPTION
This PR adds a new source type that enables CTX to connect to MCP servers and retrieve content for documentation generation.

### Features

- **MCP Source Integration**: Create a new `mcp` source type that can connect to MCP servers via command execution or HTTP/SSE
- **Server Configuration Registry**: Support for named server configurations that can be reused across sources
- **Operations**:
  - `readResource`: Read one or more resources from an MCP server
  - `callTool`: Call a tool on an MCP server with optional arguments
- **Content Formatting**: Automatically format content based on operation type and response content
- **Variable Resolution**: Support for environment variables in server configurations
- **Syntax Detection**: Automatically detect language for syntax highlighting based on content type and URI

### Configuration Examples

```yaml
# Define server configurations in settings
settings:
  mcp:
    servers:
      github:
        command: docker
        args:
          - run
          - "-i"
          - "--rm"
          - "-e"
          - "GITHUB_PERSONAL_ACCESS_TOKEN"
          - "ghcr.io/github/github-mcp-server"
        env:
          GITHUB_PERSONAL_ACCESS_TOKEN: '{{GITHUB_PAT}}'

# Use MCP sources in documents
documents:
  - description: Github issue
    outputPath: github/issue/158.md
    sources:
      - type: mcp
        server: github
        operation:
          type: tool.call
          name: get_issue
          arguments:
            owner: context-hub
            repo: generator
            issue_number: 158

      - type: mcp
        server: github
        operation:
          type: resource.read
          resources:
            - repo://context-hub/generator/contents

      # Alternatively, define server inline
      - type: mcp
        description: "Custom MCP Tool Results"
        server:
          command: "custom-mcp-server"
          args: ["--port", "8080"]
        operation:
          ...
```

This feature provides a powerful way to extend CTX's capabilities by leveraging MCP-compatible servers for documentation generation.

issue #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Model Context Protocol (MCP) integration with flexible server configurations (command- or URL-based) and a new MCP source type.
  - Enabled operations such as resource reading and tool calling, with improved connection and session management for enhanced reliability.

- **Documentation**
  - Updated configuration guides to include the new MCP source implementation and its tree-view details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->