### PR TITLE
Return Complete ConfigRegistry

### DIFF
--- a/json-schema.json
+++ b/json-schema.json
@@ -26,6 +26,10 @@
     }
   ],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "URL to the JSON schema for this configuration file"
+    },
     "tools": {
       "type": "array",
       "description": "List of custom tools to be registered for execution",

--- a/src/Config/Import/ImportRegistry.php
+++ b/src/Config/Import/ImportRegistry.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Import;
+
+use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigInterface;
+use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
+use Spiral\Core\Attribute\Singleton;
+
+/**
+ * @implements RegistryInterface<SourceConfigInterface>
+ */
+#[Singleton]
+final class ImportRegistry implements RegistryInterface
+{
+    /** @var array<SourceConfigInterface> */
+    private array $imports = [];
+
+    /**
+     * Register an import in the registry
+     */
+    public function register(SourceConfigInterface $import): self
+    {
+        $this->imports[] = $import;
+
+        return $this;
+    }
+
+    /**
+     * Gets the type of the registry.
+     */
+    public function getType(): string
+    {
+        return 'import';
+    }
+
+    /**
+     * Gets all items in the registry.
+     *
+     * @return array<SourceConfigInterface>
+     */
+    public function getItems(): array
+    {
+        return $this->imports;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'imports' => $this->imports,
+        ];
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->getItems());
+    }
+}

--- a/src/Config/Import/ResolvedConfig.php
+++ b/src/Config/Import/ResolvedConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Import;
+
+use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigInterface;
+
+final readonly class ResolvedConfig
+{
+    /**
+     * @param SourceConfigInterface[] $imports
+     */
+    public function __construct(
+        public array $config,
+        public array $imports = [],
+    ) {}
+}

--- a/src/Config/Import/Source/Config/SourceConfigInterface.php
+++ b/src/Config/Import/Source/Config/SourceConfigInterface.php
@@ -7,7 +7,7 @@ namespace Butschster\ContextGenerator\Config\Import\Source\Config;
 /**
  * Interface for all import source configurations
  */
-interface SourceConfigInterface
+interface SourceConfigInterface extends \JsonSerializable
 {
     /**
      * Get the source path

--- a/src/Config/Import/Source/ImportedConfig.php
+++ b/src/Config/Import/Source/ImportedConfig.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Import\Source;
 
+use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigInterface;
+
 /**
  * @implements \ArrayAccess<non-empty-string, mixed>
  */
 final readonly class ImportedConfig implements \ArrayAccess
 {
     public function __construct(
+        public SourceConfigInterface $sourceConfig,
         public array $config,
         public string $path,
         public bool $isLocal,

--- a/src/Config/Import/Source/Local/LocalSourceConfig.php
+++ b/src/Config/Import/Source/Local/LocalSourceConfig.php
@@ -83,6 +83,15 @@ final class LocalSourceConfig extends AbstractSourceConfig
         return \dirname($this->absolutePath);
     }
 
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->getType(),
+            'path' => $this->path,
+            'pathPrefix' => $this->pathPrefix,
+        ];
+    }
+
     /**
      * Resolve a relative path to an absolute path
      */

--- a/src/Config/Import/Source/Url/UrlSourceConfig.php
+++ b/src/Config/Import/Source/Url/UrlSourceConfig.php
@@ -17,7 +17,7 @@ final readonly class UrlSourceConfig implements SourceConfigInterface
     public function __construct(
         public string $url,
         public int $ttl = 300,
-        public readonly array $headers = [],
+        public array $headers = [],
     ) {}
 
     /**

--- a/src/Config/Import/Source/Url/UrlSourceConfig.php
+++ b/src/Config/Import/Source/Url/UrlSourceConfig.php
@@ -69,4 +69,14 @@ final readonly class UrlSourceConfig implements SourceConfigInterface
     {
         return $this->url;
     }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->getType(),
+            'url' => $this->url,
+            'ttl' => $this->ttl,
+            'headers' => $this->headers,
+        ];
+    }
 }

--- a/src/Config/Loader/CompositeConfigLoader.php
+++ b/src/Config/Loader/CompositeConfigLoader.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Loader;
 
-use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
-use Butschster\ContextGenerator\Document\DocumentRegistry;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistry;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -19,28 +18,39 @@ final readonly class CompositeConfigLoader implements ConfigLoaderInterface
         private ?LoggerInterface $logger = null,
     ) {}
 
-    public function load(): RegistryInterface
+    public function load(): ConfigRegistry
     {
         $this->logger?->debug('Trying to load with composite loader', [
             'loaderCount' => \count($this->loaders),
         ]);
 
-        $registry = new DocumentRegistry();
+        $compositeRegistry = new ConfigRegistry();
+
         foreach ($this->loaders as $loader) {
             if (!$loader->isSupported()) {
                 continue;
             }
 
             try {
-                $loadedRegistry = $loader->load();
+                $registry = $loader->load();
 
-                foreach ($loadedRegistry->getItems() as $document) {
-                    $registry->register($document);
+                // Merge all registry types from this loader
+                foreach ($registry->all() as $type => $typeRegistry) {
+                    if (!$compositeRegistry->has($type)) {
+                        $compositeRegistry->register($typeRegistry);
+                        $this->logger?->debug('Registered registry type', [
+                            'type' => $type,
+                        ]);
+                    } else {
+                        $this->logger?->debug('Registry type already exists', [
+                            'type' => $type,
+                        ]);
+                    }
                 }
 
                 $this->logger?->debug('Successfully loaded with a loader', [
                     'loaderClass' => $loader::class,
-                    'documentCount' => \count($loadedRegistry->getItems()),
+                    'registryTypes' => \array_keys($registry->all()),
                 ]);
             } catch (\Throwable $e) {
                 $this->logger?->warning('Failed to load with a loader', [
@@ -51,7 +61,7 @@ final readonly class CompositeConfigLoader implements ConfigLoaderInterface
             }
         }
 
-        return $registry;
+        return $compositeRegistry;
     }
 
     public function loadRawConfig(): array

--- a/src/Config/Loader/ConfigLoader.php
+++ b/src/Config/Loader/ConfigLoader.php
@@ -7,7 +7,7 @@ namespace Butschster\ContextGenerator\Config\Loader;
 use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
 use Butschster\ContextGenerator\Config\Parser\ConfigParserInterface;
 use Butschster\ContextGenerator\Config\Reader\ReaderInterface;
-use Butschster\ContextGenerator\Document\DocumentRegistry;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistry;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -22,9 +22,9 @@ final readonly class ConfigLoader implements ConfigLoaderInterface
         private ?LoggerInterface $logger = null,
     ) {}
 
-    public function load(): DocumentRegistry
+    public function load(): ConfigRegistry
     {
-        $this->logger?->info('Loading documents from config file', [
+        $this->logger?->info('Loading configuration from config file', [
             'configFile' => $this->configPath,
             'readerType' => $this->reader::class,
         ]);
@@ -37,21 +37,13 @@ final readonly class ConfigLoader implements ConfigLoaderInterface
             $this->logger?->debug('Parsing configuration with config parser');
             $configRegistry = $this->parser->parse($config);
 
-            // Get the DocumentRegistry from the ConfigRegistry
-            if (!$configRegistry->has('documents')) {
-                $errorMessage = 'No documents found in configuration';
-                $this->logger?->error($errorMessage);
-                throw new ConfigLoaderException($errorMessage);
-            }
-
-            $documentRegistry = $configRegistry->get('documents', DocumentRegistry::class);
-            $documentsCount = \count($documentRegistry->getItems());
-
-            $this->logger?->info('Documents loaded successfully', [
-                'documentsCount' => $documentsCount,
+            // Log the available registry types
+            $registryTypes = \array_keys($configRegistry->all());
+            $this->logger?->info('Configuration loaded successfully', [
+                'registryTypes' => $registryTypes,
             ]);
 
-            return $documentRegistry;
+            return $configRegistry;
         } catch (\Throwable $e) {
             // Wrap exceptions in a ConfigLoaderException
             throw new ConfigLoaderException(

--- a/src/Config/Loader/ConfigLoaderInterface.php
+++ b/src/Config/Loader/ConfigLoaderInterface.php
@@ -6,7 +6,7 @@ namespace Butschster\ContextGenerator\Config\Loader;
 
 use Butschster\ContextGenerator\Application\AppScope;
 use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
-use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistry;
 use Spiral\Core\Attribute\Scope;
 
 /**
@@ -16,11 +16,11 @@ use Spiral\Core\Attribute\Scope;
 interface ConfigLoaderInterface
 {
     /**
-     * Load configuration and return a document registry
+     * Load configuration and return a config registry
      *
      * @throws ConfigLoaderException If loading fails
      */
-    public function load(): RegistryInterface;
+    public function load(): ConfigRegistry;
 
     /**
      * Load raw configuration from the first supported loader

--- a/src/Config/Registry/ConfigRegistryAccessor.php
+++ b/src/Config/Registry/ConfigRegistryAccessor.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Registry;
+
+use Butschster\ContextGenerator\Config\Import\ImportRegistry;
+use Butschster\ContextGenerator\Document\DocumentRegistry;
+use Butschster\ContextGenerator\McpServer\Prompt\PromptRegistry;
+use Butschster\ContextGenerator\McpServer\Tool\ToolRegistry;
+
+/**
+ * Utility class for accessing specific registry types from ConfigRegistry
+ */
+final readonly class ConfigRegistryAccessor
+{
+    public function __construct(
+        private ConfigRegistry $registry,
+    ) {}
+
+    /**
+     * Get document registry
+     */
+    public function getDocuments(): ?DocumentRegistry
+    {
+        return $this->getRegistry('documents', DocumentRegistry::class);
+    }
+
+    /**
+     * Get prompt registry
+     */
+    public function getPrompts(): ?PromptRegistry
+    {
+        return $this->getRegistry('prompts', PromptRegistry::class);
+    }
+
+    /**
+     * Get tool registry
+     */
+    public function getTools(): ?ToolRegistry
+    {
+        return $this->getRegistry('tools', ToolRegistry::class);
+    }
+
+    /**
+     * Get import registry
+     */
+    public function getImports(): ?ImportRegistry
+    {
+        return $this->getRegistry('import', ImportRegistry::class);
+    }
+
+    /**
+     * Get a specific registry by type and class
+     *
+     * @template T of RegistryInterface
+     * @param string $type Registry type identifier
+     * @param class-string<T> $className Expected registry class
+     * @return T|null The registry or null if not found
+     */
+    private function getRegistry(string $type, string $className): ?RegistryInterface
+    {
+        if (!$this->registry->has($type)) {
+            return null;
+        }
+
+        try {
+            return $this->registry->get($type, $className);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+}

--- a/src/Config/Registry/RegistryInterface.php
+++ b/src/Config/Registry/RegistryInterface.php
@@ -7,8 +7,9 @@ namespace Butschster\ContextGenerator\Config\Registry;
 /**
  * Common interface for all registries
  * @template TItem of mixed
+ * @extends \IteratorAggregate<TItem>
  */
-interface RegistryInterface extends \JsonSerializable
+interface RegistryInterface extends \JsonSerializable, \IteratorAggregate
 {
     /**
      * Get the registry type identifier

--- a/src/Config/context.yaml
+++ b/src/Config/context.yaml
@@ -10,6 +10,13 @@ documents:
           - ../Application/Bootloader/ConfigLoaderBootloader.php
           - ../Application/Bootloader/ImportBootloader.php
 
+  - description: Configuration Import
+    outputPath: core/config-import.md
+    sources:
+      - type: file
+        sourcePaths:
+          - ./Import
+
   - description: Configuration Parser
     outputPath: core/config-parser.md
     sources:

--- a/src/Console/DisplayCommand.php
+++ b/src/Console/DisplayCommand.php
@@ -7,6 +7,7 @@ namespace Butschster\ContextGenerator\Console;
 use Butschster\ContextGenerator\Application\AppScope;
 use Butschster\ContextGenerator\Config\ConfigurationProvider;
 use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\Console\Renderer\DocumentRenderer;
 use Butschster\ContextGenerator\Console\Renderer\Style;
 use Butschster\ContextGenerator\DirectoriesInterface;
@@ -76,13 +77,13 @@ final class DisplayCommand extends BaseCommand
 
                 try {
                     // Load the document registry
-                    $registry = $loader->load();
+                    $registry = new ConfigRegistryAccessor($loader->load());
 
                     $title = "Context: " . (string) $dirs->getRootPath();
 
                     $this->output->writeln("\n" . Style::header($title));
                     $this->output->writeln(Style::separator('=', \strlen($title)) . "\n");
-                    $documents = $registry->getItems();
+                    $documents = $registry->getDocuments()->getItems();
                     $this->output->writeln(
                         Style::property("Total documents") . ": " . Style::count(\count($documents)) . "\n\n",
                     );

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -7,6 +7,7 @@ namespace Butschster\ContextGenerator\Console;
 use Butschster\ContextGenerator\Application\AppScope;
 use Butschster\ContextGenerator\Config\ConfigurationProvider;
 use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\Console\Renderer\GenerateCommandRenderer;
 use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
@@ -90,7 +91,11 @@ final class GenerateCommand extends BaseCommand
                 // Display summary header
                 $this->output->writeln('');
 
-                foreach ($loader->load()->getItems() as $document) {
+                $config = new ConfigRegistryAccessor($loader->load());
+
+                $renderer->renderImports($config->getImports());
+
+                foreach ($config->getDocuments() as $document) {
                     $this->logger->info(\sprintf('Compiling %s...', $document->description));
 
                     $compiledDocument = $compiler->compile($document);

--- a/src/Console/Renderer/GenerateCommandRenderer.php
+++ b/src/Console/Renderer/GenerateCommandRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Console\Renderer;
 
+use Butschster\ContextGenerator\Config\Import\ImportRegistry;
 use Butschster\ContextGenerator\Document\Compiler\CompiledDocument;
 use Butschster\ContextGenerator\Document\Document;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,7 +18,7 @@ final readonly class GenerateCommandRenderer
     /**
      * Maximum line width for consistent display
      */
-    private const int MAX_LINE_WIDTH = 120;
+    private const int MAX_LINE_WIDTH = 100;
 
     /**
      * Success indicator symbol
@@ -36,7 +37,36 @@ final readonly class GenerateCommandRenderer
 
     public function __construct(
         private OutputInterface $output,
-    ) {}
+    ) {
+    }
+
+    public function renderImports(ImportRegistry $imports): void
+    {
+        \assert($this->output instanceof SymfonyStyle);
+        foreach ($imports as $item) {
+            $description = $item->getPath();
+
+            if (\strlen($description) > self::MAX_LINE_WIDTH - 40) {
+                $halfLength = (self::MAX_LINE_WIDTH - 40) / 2;
+                $description = \substr($description, 0, $halfLength) . '...' . \substr($description, -$halfLength);
+            }
+
+            // Calculate padding to align the document descriptions
+            $padding = $this->calculatePadding($item->getType(), $description, 12);
+
+            $this->output->writeln(
+                \sprintf(
+                    ' <fg=yellow>%s</> Import %s <fg=yellow>[%s]</><fg=gray>%s</>',
+                    $this->padRight(self::SUCCESS_SYMBOL, 1),
+                    $item->getType(),
+                    $description,
+                    $padding,
+                ),
+            );
+        }
+
+        $this->output->newLine();
+    }
 
     /**
      * Render the compilation result for a document
@@ -44,7 +74,6 @@ final readonly class GenerateCommandRenderer
     public function renderCompilationResult(Document $document, CompiledDocument $compiledDocument): void
     {
         \assert($this->output instanceof SymfonyStyle);
-
         $hasErrors = $compiledDocument->errors->hasErrors();
         $description = $document->description;
         $outputPath = $document->outputPath;
@@ -87,9 +116,9 @@ final readonly class GenerateCommandRenderer
     /**
      * Calculate padding to align the document information
      */
-    private function calculatePadding(string $description, string $outputPath): string
+    private function calculatePadding(string $description, string $outputPath, int $additional = 5): string
     {
-        $totalLength = \strlen($description) + \strlen($outputPath) + 5; // 5 accounts for spaces and brackets
+        $totalLength = \strlen($description) + \strlen($outputPath) + $additional;
         $padding = \max(0, self::MAX_LINE_WIDTH - $totalLength);
 
         return \str_repeat('.', $padding);

--- a/src/Console/Renderer/GenerateCommandRenderer.php
+++ b/src/Console/Renderer/GenerateCommandRenderer.php
@@ -37,8 +37,7 @@ final readonly class GenerateCommandRenderer
 
     public function __construct(
         private OutputInterface $output,
-    ) {
-    }
+    ) {}
 
     public function renderImports(ImportRegistry $imports): void
     {

--- a/src/Document/DocumentRegistry.php
+++ b/src/Document/DocumentRegistry.php
@@ -40,4 +40,9 @@ final class DocumentRegistry implements RegistryInterface
     {
         return $this->documents;
     }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->getItems());
+    }
 }

--- a/src/McpServer/Action/Resources/GetDocumentContentResourceAction.php
+++ b/src/McpServer/Action/Resources/GetDocumentContentResourceAction.php
@@ -6,6 +6,7 @@ namespace Butschster\ContextGenerator\McpServer\Action\Resources;
 
 use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
 use Butschster\ContextGenerator\Document\Compiler\Error\ErrorCollection;
 use Butschster\ContextGenerator\McpServer\Routing\Attribute\Get;
@@ -29,10 +30,10 @@ final readonly class GetDocumentContentResourceAction
         $path = $request->getAttribute('path');
         $this->logger->info('Getting document content', ['path' => $path]);
 
-        $documents = $this->configLoader->load();
+        $config = new ConfigRegistryAccessor($this->configLoader->load());
         $contents = [];
 
-        foreach ($documents->getItems() as $document) {
+        foreach ($config->getDocuments() as $document) {
             if ($document->outputPath === $path) {
                 $contents[] = new TextResourceContents(
                     text: (string) $this->compiler->buildContent(new ErrorCollection(), $document)->content,

--- a/src/McpServer/Action/Resources/ListResourcesAction.php
+++ b/src/McpServer/Action/Resources/ListResourcesAction.php
@@ -6,6 +6,7 @@ namespace Butschster\ContextGenerator\McpServer\Action\Resources;
 
 use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\McpServer\McpConfig;
 use Butschster\ContextGenerator\McpServer\Registry\McpItemsRegistry;
 use Butschster\ContextGenerator\McpServer\Routing\Attribute\Get;
@@ -37,9 +38,9 @@ final readonly class ListResourcesAction
         }
 
         // Add document resources from config loader
-        $documents = $this->configLoader->load();
+        $config = new ConfigRegistryAccessor($this->configLoader->load());
 
-        foreach ($documents->getItems() as $document) {
+        foreach ($config->getDocuments() as $document) {
             $tags = \implode(', ', $document->getTags());
 
             $resources[] = new Resource(

--- a/src/McpServer/Action/Tools/Context/ContextAction.php
+++ b/src/McpServer/Action/Tools/Context/ContextAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\McpServer\Action\Tools\Context;
 
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\McpServer\Attribute\Tool;
 use Butschster\ContextGenerator\McpServer\Routing\Attribute\Post;
 use Mcp\Types\CallToolResult;
@@ -29,10 +30,10 @@ final readonly class ContextAction
         $this->logger->info('Processing context tool');
 
         try {
-            $documents = $this->configLoader->load();
+            $config = new ConfigRegistryAccessor($this->configLoader->load());
 
             $content = [];
-            foreach ($documents->getItems() as $document) {
+            foreach ($config->getDocuments() as $document) {
                 $content[] = new TextContent(
                     text: \json_encode($document->jsonSerialize()),
                 );

--- a/src/McpServer/Action/Tools/Context/ContextGetAction.php
+++ b/src/McpServer/Action/Tools/Context/ContextGetAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\McpServer\Action\Tools\Context;
 
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
 use Butschster\ContextGenerator\Document\Compiler\Error\ErrorCollection;
 use Butschster\ContextGenerator\McpServer\Attribute\InputSchema;
@@ -51,9 +52,9 @@ final readonly class ContextGetAction
         }
 
         try {
-            $documents = $this->configLoader->load();
+            $config = new ConfigRegistryAccessor($this->configLoader->load());
 
-            foreach ($documents->getItems() as $document) {
+            foreach ($config->getDocuments() as $document) {
                 if ($document->outputPath === $path) {
                     $content = new TextContent(
                         text: (string) $this->documentCompiler->buildContent(new ErrorCollection(), $document)->content,

--- a/src/McpServer/Action/Tools/Context/ContextRequestAction.php
+++ b/src/McpServer/Action/Tools/Context/ContextRequestAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\McpServer\Action\Tools\Context;
 
 use Butschster\ContextGenerator\Config\ConfigurationProvider;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
 use Butschster\ContextGenerator\Document\Compiler\Error\ErrorCollection;
 use Butschster\ContextGenerator\McpServer\Attribute\InputSchema;
@@ -52,10 +53,10 @@ final readonly class ContextRequestAction
 
         try {
             $loader = $this->provider->fromString($json);
-            $documents = $loader->load()->getItems();
+            $config = new ConfigRegistryAccessor($loader->load());
             $compiledDocuments = [];
 
-            foreach ($documents as $document) {
+            foreach ($config->getDocuments() as $document) {
                 $compiledDocuments[] = new TextContent(
                     text: (string) $this->documentCompiler->buildContent(new ErrorCollection(), $document)->content,
                 );

--- a/src/McpServer/Prompt/PromptRegistry.php
+++ b/src/McpServer/Prompt/PromptRegistry.php
@@ -74,4 +74,9 @@ final class PromptRegistry implements RegistryInterface, PromptProviderInterface
             'prompts' => \array_values($this->prompts),
         ];
     }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->getItems());
+    }
 }

--- a/src/McpServer/Tool/ToolRegistry.php
+++ b/src/McpServer/Tool/ToolRegistry.php
@@ -72,4 +72,9 @@ final class ToolRegistry implements RegistryInterface, ToolProviderInterface, To
             'tools' => $this->getItems(),
         ];
     }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->getItems());
+    }
 }

--- a/tests/src/Feature/Compiler/AbstractCompilerTestCase.php
+++ b/tests/src/Feature/Compiler/AbstractCompilerTestCase.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Compiler;
 use Butschster\ContextGenerator\Application\AppScope;
 use Butschster\ContextGenerator\Application\FSPath;
 use Butschster\ContextGenerator\Config\ConfigurationProvider;
+use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
 use PHPUnit\Framework\Attributes\Test;
 use Spiral\Core\Scope;
@@ -54,7 +55,9 @@ abstract class AbstractCompilerTestCase extends AppTestCase
 
         $outputPaths = [];
         $results = [];
-        foreach ($loader->load()->getItems() as $document) {
+
+        $config = new ConfigRegistryAccessor($loader->load());
+        foreach ($config->getDocuments() as $document) {
             $outputPaths[] = $this->getContextsDir($document->outputPath);
             $compiledDocument = $compiler->compile($document);
 


### PR DESCRIPTION
Currently, the `ConfigLoader` only returns the `DocumentRegistry`, ignoring other important registry types like Imports, Prompts, Tools, etc. This limits access to these configurations elsewhere in the application.

## Solution
This PR refactors the `ConfigLoader` to return the entire `ConfigRegistry` instead of just the `DocumentRegistry`. It adds a new `ConfigRegistryAccessor` utility for type-safe access to various registry types and introduces a new `ImportRegistry` for tracking import configurations.