### PR TITLE
Add maxFiles parameter to FileSource

### DIFF
--- a/json-schema.json
+++ b/json-schema.json
@@ -1175,6 +1175,12 @@
           ],
           "description": "Patterns to include only specific paths"
         },
+        "maxFiles": {
+          "type": ["integer"],
+          "description": "Maximum number of files to include (0 for no limit)",
+          "minimum": 0,
+          "default": 0
+        },
         "contains": {
           "oneOf": [
             {

--- a/src/Source/Composer/ComposerSource.php
+++ b/src/Source/Composer/ComposerSource.php
@@ -95,6 +95,11 @@ final class ComposerSource extends SourceWithModifiers implements FilterableSour
         return true;
     }
 
+    public function maxFiles(): int
+    {
+        return 0; //todo Add support for max files
+    }
+
     #[\Override]
     public function jsonSerialize(): array
     {

--- a/src/Source/Fetcher/FilterableSourceInterface.php
+++ b/src/Source/Fetcher/FilterableSourceInterface.php
@@ -69,4 +69,10 @@ interface FilterableSourceInterface
      * Check if unreadable directories should be ignored
      */
     public function ignoreUnreadableDirs(): bool;
+
+    /**
+     * Get maximum number of files to return
+     * @return non-negative-int Maximum number of files (0 for no limit)
+     */
+    public function maxFiles(): int;
 }

--- a/src/Source/File/FileSource.php
+++ b/src/Source/File/FileSource.php
@@ -25,6 +25,7 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
      * @param string|array<string> $size Size constraints for files (e.g., '> 10K', '< 1M')
      * @param string|array<string> $date Date constraints for files (e.g., 'since yesterday', '> 2023-01-01')
      * @param bool $ignoreUnreadableDirs Whether to ignore unreadable directories
+     * @param non-negative-int $maxFiles Maximum number of files to include (0 for no limit)
      * @param array<Modifier> $modifiers Identifiers for content modifiers to apply
      * @param array<non-empty-string> $tags
      */
@@ -40,6 +41,7 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
         public readonly string|array $date = [],
         public readonly bool $ignoreUnreadableDirs = false,
         public readonly TreeViewConfig $treeView = new TreeViewConfig(),
+        public readonly int $maxFiles = 0,
         array $modifiers = [],
         array $tags = [],
     ) {
@@ -114,6 +116,11 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
         return $this->ignoreUnreadableDirs;
     }
 
+    public function maxFiles(): int
+    {
+        return $this->maxFiles;
+    }
+
     #[\Override]
     public function jsonSerialize(): array
     {
@@ -149,6 +156,11 @@ final class FileSource extends SourceWithModifiers implements FilterableSourceIn
 
         if ($this->ignoreUnreadableDirs) {
             $result['ignoreUnreadableDirs'] = true;
+        }
+
+        // Add maxFiles only if it's set and not zero
+        if ($this->maxFiles !== null && $this->maxFiles > 0) {
+            $result['maxFiles'] = $this->maxFiles;
         }
 
         return \array_filter($result);

--- a/src/Source/File/FileSourceFactory.php
+++ b/src/Source/File/FileSourceFactory.php
@@ -62,6 +62,17 @@ final readonly class FileSourceFactory extends AbstractSourceFactory
             }
         }
 
+        // Validate maxFiles if present
+        if (isset($config['maxFiles']) && $config['maxFiles'] !== null) {
+            if (!\is_int($config['maxFiles'])) {
+                throw new \RuntimeException('maxFiles must be an integer or null');
+            }
+
+            if ($config['maxFiles'] < 0) {
+                throw new \RuntimeException('maxFiles cannot be negative');
+            }
+        }
+
         // Handle filePattern parameter, allowing both string and array formats
         $filePattern = $config['filePattern'] ?? '*.*';
 
@@ -81,6 +92,7 @@ final readonly class FileSourceFactory extends AbstractSourceFactory
             date: $config['date'] ?? [],
             ignoreUnreadableDirs: $config['ignoreUnreadableDirs'] ?? false,
             treeView: TreeViewConfig::fromArray($config),
+            maxFiles: $config['maxFiles'] ?? 0,
             modifiers: $config['modifiers'] ?? [],
             tags: $config['tags'] ?? [],
         );

--- a/src/Source/File/SymfonyFinder.php
+++ b/src/Source/File/SymfonyFinder.php
@@ -97,9 +97,37 @@ final readonly class SymfonyFinder implements FinderInterface
 
         $finder->sortByName();
 
+        // Check for maxFiles limit
+        $maxFiles = $source->maxFiles();
+        $hasLimit = $maxFiles !== null && $maxFiles > 0;
+
+        // Generate tree view (always on all files for consistency)
+        $treeView = $this->generateTreeView($finder, $basePath, $options);
+
+        // Get files with limit if needed
+        if ($hasLimit) {
+            $limitedFiles = [];
+            $count = 0;
+
+            foreach ($finder as $file) {
+                $limitedFiles[] = $file;
+                $count++;
+
+                if ($count >= $maxFiles) {
+                    break;
+                }
+            }
+
+            return new FinderResult(
+                files: $limitedFiles,
+                treeView: $treeView,
+            );
+        }
+
+        // No limit, return all files
         return new FinderResult(
             files: \array_values(\iterator_to_array($finder->getIterator())),
-            treeView: $this->generateTreeView($finder, $basePath, $options),
+            treeView: $treeView,
         );
     }
 

--- a/src/Source/GitDiff/GitDiffSource.php
+++ b/src/Source/GitDiff/GitDiffSource.php
@@ -98,6 +98,11 @@ final class GitDiffSource extends SourceWithModifiers implements FilterableSourc
         return false;
     }
 
+    public function maxFiles(): int
+    {
+        return 0; //todo Add support for max files
+    }
+
     #[\Override]
     public function jsonSerialize(): array
     {

--- a/src/Source/Github/GithubSource.php
+++ b/src/Source/Github/GithubSource.php
@@ -92,6 +92,11 @@ final class GithubSource extends SourceWithModifiers implements FilterableSource
         return false; // Not applicable for GitHub sources
     }
 
+    public function maxFiles(): int
+    {
+        return 0; //todo Add support for max files
+    }
+
     #[\Override]
     public function jsonSerialize(): array
     {

--- a/src/Source/Tree/TreeSource.php
+++ b/src/Source/Tree/TreeSource.php
@@ -106,6 +106,11 @@ final class TreeSource extends BaseSource implements FilterableSourceInterface
         return true;
     }
 
+    public function maxFiles(): int
+    {
+        return 0;
+    }
+
     #[\Override]
     public function jsonSerialize(): array
     {


### PR DESCRIPTION
This PR adds the ability to limit the number of files processed from a directory or pattern match using a new `maxFiles` parameter to the FileSource class. This is particularly useful when working with large directories to limit processing to just the files you need.

### Usage Example
```yaml
documents:
  - description: "Limited Files Example"
    outputPath: "docs/limited-files.md"
    sources:
      - type: file
        description: "First 10 PHP Files"
        sourcePaths: src
        filePattern: "*.php"
        maxFiles: 10
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable option to limit the number of files processed. A value of 0 indicates no limit.
  - Enhanced file handling to respect this file limit across various components.
  - Added validations to ensure only non-negative values are accepted, improving configuration robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->