### PR TITLE
Dynamic Project Switching for MCP Server

### DIFF
--- a/app.php
+++ b/app.php
@@ -92,11 +92,19 @@ $container->bindSingleton(
 //  Execute Application
 // -----------------------------------------------------------------------------
 
+// Determine appropriate location for global state based on OS
+$globalStateDir = match (PHP_OS_FAMILY) {
+    'Windows' => \getenv('APPDATA') . '/CTX',
+    'Darwin' => $_SERVER['HOME'] . '/Library/Application Support/CTX',
+    default => $_SERVER['HOME'] . '/.config/ctx',
+};
+
 $app = Kernel::create(
     directories: [
         'root' => $appPath,
         'output' => $appPath . '/.context',
         'config' => $appPath,
+        'global-state' => $globalStateDir,
         'json-schema' => __DIR__,
     ],
     exceptionHandler: ExceptionHandler::class,

--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -18,7 +18,6 @@ use Butschster\ContextGenerator\Application\Bootloader\ModifierBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\SourceFetcherBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\VariableBootloader;
 use Butschster\ContextGenerator\McpServer\McpServerBootloader;
-use Butschster\ContextGenerator\McpServer\Prompt\McpPromptBootloader;
 use Butschster\ContextGenerator\Modifier\PhpContentFilter\PhpContentFilterBootloader;
 use Butschster\ContextGenerator\Modifier\PhpDocs\PhpDocsModifierBootloader;
 use Butschster\ContextGenerator\Modifier\PhpSignature\PhpSignatureModifierBootloader;
@@ -83,7 +82,6 @@ class Kernel extends AbstractKernel
 
             // MCP Server
             McpServerBootloader::class,
-            McpPromptBootloader::class,
         ];
     }
 

--- a/src/Config/Import/Merger/VariablesConfigMerger.php
+++ b/src/Config/Import/Merger/VariablesConfigMerger.php
@@ -10,14 +10,14 @@ use Butschster\ContextGenerator\Config\Import\Source\ImportedConfig;
 #[LoggerPrefix(prefix: 'variables-merger')]
 final readonly class VariablesConfigMerger extends AbstractConfigMerger
 {
+    public function getConfigKey(): string
+    {
+        return 'variables';
+    }
+
     protected function performMerge(array $mainSection, array $importedSection, ImportedConfig $importedConfig): array
     {
         // Merge the variables from the imported config into the main config
         return [...$importedSection, ...$mainSection];
-    }
-
-    public function getConfigKey(): string
-    {
-        return 'variables';
     }
 }

--- a/src/Config/Loader/ConfigLoaderFactory.php
+++ b/src/Config/Loader/ConfigLoaderFactory.php
@@ -30,7 +30,7 @@ final readonly class ConfigLoaderFactory implements ConfigLoaderFactoryInterface
     public function create(string $configPath): ConfigLoaderInterface
     {
         $dirs = $this->dirs->withConfigPath($configPath);
-        $configPathObj = $dirs->getConfigPath();
+        $configPathObj = $dirs->getRootPath();
 
         // Create composite parser using the injected plugin registry
         $compositeParser = new CompositeConfigParser(

--- a/src/Console/Renderer/Style.php
+++ b/src/Console/Renderer/Style.php
@@ -5,153 +5,96 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Console\Renderer;
 
 /**
- * @deprecated Should be completely redesigned
+ * Console output styling utilities
  */
 final class Style
 {
     /**
-     * Format a section header (large titles)
+     * Create a header styled text
      */
     public static function header(string $text): string
     {
-        return "\033[1;33m" . $text . "\033[0m";
-    }
-
-    /**
-     * Format a title (section names)
-     */
-    public static function title(string $text): string
-    {
-        return "\033[1;36m" . $text . "\033[0m";
-    }
-
-    /**
-     * Format a subtitle (smaller section names)
-     */
-    public static function subtitle(string $text): string
-    {
-        return "\033[1;34m" . $text . "\033[0m";
-    }
-
-    /**
-     * Format a property name
-     */
-    public static function property(string $text): string
-    {
-        return "\033[1;32m" . $text . "\033[0m";
-    }
-
-    /**
-     * Format a value
-     */
-    public static function value(mixed $value): string
-    {
-        if (\is_bool($value)) {
-            return $value ? "\033[0;32mtrue\033[0m" : "\033[0;31mfalse\033[0m";
-        }
-
-        if (\is_string($value)) {
-            return "\033[0;33m\"" . $value . "\"\033[0m";
-        }
-
-        if (\is_null($value)) {
-            return "\033[0;90mnull\033[0m";
-        }
-
-        if (\is_numeric($value)) {
-            return "\033[0;36m" . (string) $value . "\033[0m";
-        }
-
-        return (string) $value;
-    }
-
-    /**
-     * Format array values
-     */
-    public static function array(array $values): string
-    {
-        if (empty($values)) {
-            return "\033[0;90m[]\033[0m";
-        }
-
-        if (\array_keys($values) === \range(0, \count($values) - 1)) {
-            // Sequential array
-            $formattedItems = \array_map(
-                static fn($item) => \is_array($item) ? self::array($item) : self::value($item),
-                $values,
-            );
-            return "\033[0;33m[" . \implode(", ", $formattedItems) . "]\033[0m";
-        }
-
-        // Associative array
-        $result = "{\n";
-        foreach ($values as $key => $value) {
-            $formattedValue = \is_array($value) ? self::array($value) : self::value($value);
-            $result .= self::indent(self::property('"' . $key . '"') . ": " . $formattedValue) . "\n";
-        }
-        $result .= '}';
-        return $result;
-    }
-
-    /**
-     * Format a key-value pair
-     */
-    public static function keyValue(string $key, mixed $value): string
-    {
-        $formattedValue = \is_array($value) ? self::array($value) : self::value($value);
-        return self::property($key) . ": " . $formattedValue;
-    }
-
-    /**
-     * Format a count indicator
-     */
-    public static function count(int $count): string
-    {
-        return "\033[1;35m" . $count . "\033[0m";
-    }
-
-    /**
-     * Format an item number in a list
-     */
-    public static function itemNumber(int $number, int $total = 10): string
-    {
-        return "\033[1;35m" . $number . '/' . $total . "\033[0m";
-    }
-
-    /**
-     * Format path text
-     */
-    public static function path(string $path): string
-    {
-        return "\033[0;36m" . $path . "\033[0m";
-    }
-
-    /**
-     * Format a preview of content
-     */
-    public static function contentPreview(string $content): string
-    {
-        $preview = \substr($content, 0, 100);
-        if (\strlen($content) > 100) {
-            $preview .= '...';
-        }
-        return "\033[0;90m\"" . \str_replace(["\r", "\n"], ["\\r", "\\n"], $preview) . "\"\033[0m";
-    }
-
-    /**
-     * Indent a text block
-     */
-    public static function indent(string $text, int $level = 1): string
-    {
-        $indent = \str_repeat('  ', $level);
-        return $indent . \str_replace("\n", "\n" . $indent, $text);
+        return \sprintf('<fg=bright-blue;options=bold>%s</>', $text);
     }
 
     /**
      * Create a separator line
      */
-    public static function separator(string $char = '-', int $length = 30): string
+    public static function separator(string $char = '-', int $length = 80): string
     {
-        return "\033[0;90m" . \str_repeat($char, $length) . "\033[0m";
+        return \sprintf('<fg=blue>%s</>', \str_repeat($char, $length));
+    }
+
+    /**
+     * Create a property name styled text
+     */
+    public static function property(string $text): string
+    {
+        return \sprintf('<fg=bright-cyan>%s</>', $text);
+    }
+
+    /**
+     * Create a label styled text
+     */
+    public static function label(string $text): string
+    {
+        return \sprintf('<fg=yellow>%s</>', $text);
+    }
+
+    /**
+     * Create a count styled text
+     */
+    public static function count(int $count): string
+    {
+        return \sprintf('<fg=bright-magenta>%d</>', $count);
+    }
+
+    /**
+     * Create an item number styled text
+     */
+    public static function itemNumber(int $current, int $total): string
+    {
+        return \sprintf('<fg=bright-yellow>%d/%d</>', $current, $total);
+    }
+
+    /**
+     * Create indented text
+     */
+    public static function indent(string $text, int $spaces = 2): string
+    {
+        $indent = \str_repeat(' ', $spaces);
+        return $indent . \str_replace("\n", "\n" . $indent, $text);
+    }
+
+    /**
+     * Create success styled text
+     */
+    public static function success(string $text): string
+    {
+        return \sprintf('<fg=green>%s</>', $text);
+    }
+
+    /**
+     * Create error styled text
+     */
+    public static function error(string $text): string
+    {
+        return \sprintf('<fg=red>%s</>', $text);
+    }
+
+    /**
+     * Create warning styled text
+     */
+    public static function warning(string $text): string
+    {
+        return \sprintf('<fg=yellow>%s</>', $text);
+    }
+
+    /**
+     * Create highlighted text
+     */
+    public static function highlight(string $text): string
+    {
+        return \sprintf('<fg=bright-green>%s</>', $text);
     }
 }

--- a/src/McpServer/Console/MCPServerCommand.php
+++ b/src/McpServer/Console/MCPServerCommand.php
@@ -13,6 +13,7 @@ use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
 use Butschster\ContextGenerator\Config\Loader\ConfigLoaderInterface;
 use Butschster\ContextGenerator\Console\BaseCommand;
 use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\McpServer\Projects\ProjectService;
 use Butschster\ContextGenerator\McpServer\ProjectService\ProjectServiceFactory;
 use Butschster\ContextGenerator\McpServer\ProjectService\ProjectServiceInterface;
 use Butschster\ContextGenerator\McpServer\ServerRunnerInterface;
@@ -45,8 +46,25 @@ final class MCPServerCommand extends BaseCommand
     )]
     protected ?string $envFileName = null;
 
-    public function __invoke(Container $container, DirectoriesInterface $dirs, Application $app): int
-    {
+    public function __invoke(
+        Container $container,
+        DirectoriesInterface $dirs,
+        Application $app,
+        ProjectService $projects,
+    ): int {
+        $currentProject = $projects->getCurrentProject();
+        if ($this->configPath === null && $currentProject) {
+            $this->configPath = $currentProject->hasConfigFile()
+                ? $currentProject->getConfigFile()
+                : $currentProject->path;
+
+            if ($this->envFileName === null) {
+                $this->envFileName = $currentProject->hasEnvFile()
+                    ? $currentProject->getEnvFile()
+                    : null;
+            }
+        }
+
         // Determine the effective root path based on config file path
         $dirs = $dirs
             ->determineRootPath($this->configPath)

--- a/src/McpServer/McpServerBootloader.php
+++ b/src/McpServer/McpServerBootloader.php
@@ -28,7 +28,9 @@ use Butschster\ContextGenerator\McpServer\Action\Tools\ListToolsAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Prompts\GetPromptToolAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Prompts\ListPromptsToolAction;
 use Butschster\ContextGenerator\McpServer\Console\MCPServerCommand;
+use Butschster\ContextGenerator\McpServer\Projects\McpProjectsBootloader;
 use Butschster\ContextGenerator\McpServer\ProjectService\ProjectServiceInterface;
+use Butschster\ContextGenerator\McpServer\Prompt\McpPromptBootloader;
 use Butschster\ContextGenerator\McpServer\Registry\McpItemsRegistry;
 use Butschster\ContextGenerator\McpServer\Routing\McpResponseStrategy;
 use Butschster\ContextGenerator\McpServer\Routing\RouteRegistrar;
@@ -55,6 +57,9 @@ final class McpServerBootloader extends Bootloader
         return [
             HttpClientBootloader::class,
             McpToolBootloader::class,
+            McpPromptBootloader::class,
+            McpProjectsBootloader::class,
+
         ];
     }
 

--- a/src/McpServer/Projects/Console/ProjectAddCommand.php
+++ b/src/McpServer/Projects/Console/ProjectAddCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Console;
+
+use Butschster\ContextGenerator\Application\AppScope;
+use Butschster\ContextGenerator\Application\FSPath;
+use Butschster\ContextGenerator\Config\ConfigurationProvider;
+use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
+use Butschster\ContextGenerator\Console\BaseCommand;
+use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\McpServer\Projects\ProjectService;
+use Spiral\Console\Attribute\Argument;
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Attribute\Option;
+use Spiral\Core\Container;
+use Spiral\Core\Scope;
+use Spiral\Files\FilesInterface;
+use Symfony\Component\Console\Command\Command;
+
+#[AsCommand(
+    name: 'project:add',
+    description: 'Add an additional project context',
+)]
+final class ProjectAddCommand extends BaseCommand
+{
+    #[Argument(
+        name: 'path',
+        description: 'Path to the project directory. Use "." for current directory',
+    )]
+    protected string $path;
+
+    #[Option(
+        name: 'name',
+        description: 'Alias name for the project',
+    )]
+    protected ?string $name = null;
+
+    #[Option(
+        name: 'config-file',
+        shortcut: 'c',
+        description: 'Path to custom configuration file within the project',
+    )]
+    protected ?string $configFile = null;
+
+    #[Option(
+        name: 'env-file',
+        shortcut: 'e',
+        description: 'Path to .env file within the project',
+    )]
+    protected ?string $envFile = null;
+
+    public function __invoke(
+        Container $container,
+        DirectoriesInterface $dirs,
+        FilesInterface $files,
+        ProjectService $projectService,
+        ConfigurationProvider $configProvider,
+    ): int {
+        // Handle using an alias as the path
+        $resolvedPath = $projectService->resolvePathOrAlias($this->path);
+        if ($resolvedPath !== $this->path) {
+            $this->logger->info(\sprintf("Resolved alias '%s' to path: %s", $this->path, $resolvedPath));
+            $this->path = $resolvedPath;
+        }
+
+        // Normalize path to absolute path
+        $projectPath = $this->normalizePath($this->path, $dirs);
+
+        // Validate project path
+        if (!$files->exists($projectPath)) {
+            $this->output->error(\sprintf("Project path does not exist: %s", $projectPath));
+            return Command::FAILURE;
+        }
+
+        if (!$files->isDirectory($projectPath)) {
+            $this->output->error(\sprintf("Project path is not a directory: %s", $projectPath));
+            return Command::FAILURE;
+        }
+
+        // Check if the path contains a valid config file
+        $configPath = $this->configFile ?
+            FSPath::create($projectPath)->join($this->configFile)->toString() :
+            null;
+
+        // Validate env file path if provided
+        if ($this->envFile !== null) {
+            $envPath = FSPath::create($projectPath)->join($this->envFile)->toString();
+            if (!$files->exists($envPath)) {
+                $this->output->warning(\sprintf("Env file does not exist: %s", $envPath));
+                // Not returning failure here, just warning the user
+            }
+        }
+
+        try {
+            // Verify config can be loaded
+            if ($configPath !== null) {
+                $configLoader = $configProvider->fromPath($configPath);
+            } else {
+                // Create temporary directories to test config loading
+                $tempDirs = $dirs->determineRootPath(null, null)->withRootPath($projectPath);
+
+                $container->runScope(
+                    bindings: new Scope(
+                        name: AppScope::Compiler,
+                        bindings: [
+                            DirectoriesInterface::class => $tempDirs,
+                        ],
+                    ),
+                    scope: static function () use ($configProvider): void {
+                        $configProvider->fromDefaultLocation()->load();
+                    },
+                );
+            }
+        } catch (ConfigLoaderException $e) {
+            $this->output->error(
+                \sprintf(
+                    "No valid context configuration found in %s: %s",
+                    $projectPath,
+                    $e->getMessage(),
+                ),
+            );
+            return Command::FAILURE;
+        }
+
+        // Add the project
+        $projectService->addProject($projectPath, $this->name, $this->configFile, $this->envFile);
+
+        $this->output->success(\sprintf("Added project: %s", $projectPath));
+
+        if ($this->name) {
+            $this->output->info(\sprintf("Project alias '%s' has been set", $this->name));
+        }
+
+        if ($this->envFile) {
+            $this->output->info(\sprintf("Project env file '%s' has been set", $this->envFile));
+        }
+
+        // If this is the first project, also set it as the current project
+        if (\count($projectService->getProjects()) === 1) {
+            $projectService->setCurrentProject($projectPath, $this->name, $this->configFile, $this->envFile);
+            $this->output->info('Project was automatically set as the current project (first project added).');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Normalize a path to an absolute path
+     */
+    private function normalizePath(string $path, DirectoriesInterface $dirs): string
+    {
+        // Handle special case for current directory
+        if ($path === '.') {
+            return (string) FSPath::cwd();
+        }
+
+        $pathObj = FSPath::create($path);
+
+        // If path is relative, make it absolute from the current directory
+        if ($pathObj->isRelative()) {
+            $pathObj = $pathObj->absolute();
+        }
+
+        return $pathObj->toString();
+    }
+}

--- a/src/McpServer/Projects/Console/ProjectCommand.php
+++ b/src/McpServer/Projects/Console/ProjectCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Console;
+
+use Butschster\ContextGenerator\Application\FSPath;
+use Butschster\ContextGenerator\Console\BaseCommand;
+use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\McpServer\Projects\ProjectService;
+use Spiral\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+#[AsCommand(
+    name: 'project',
+    description: 'Manage projects and change the working directory',
+)]
+final class ProjectCommand extends BaseCommand
+{
+    #[Argument(
+        name: 'path',
+        description: 'Path or alias to the project. Use "." for current directory.',
+    )]
+    protected ?string $path = null;
+
+    public function __invoke(DirectoriesInterface $dirs, ProjectService $projectService): int
+    {
+        // If no path provided, show interactive selection or current project
+        if ($this->path === null) {
+            return $this->selectProjectInteractively($projectService);
+        }
+
+        // Handle using an alias as the path
+        $resolvedPath = $projectService->resolvePathOrAlias($this->path);
+        if ($resolvedPath !== $this->path) {
+            $this->logger->info(\sprintf("Resolved alias '%s' to path: %s", $this->path, $resolvedPath));
+            $this->path = $resolvedPath;
+        }
+
+        // Normalize path to absolute path
+        $projectPath = $this->normalizePath($this->path, $dirs);
+
+        // First, try to switch to this project if it exists
+        if ($projectService->switchToProject($projectPath)) {
+            $this->output->success(\sprintf("Switched to project: %s", $projectPath));
+            return Command::SUCCESS;
+        }
+
+        $this->output->error(\sprintf("Project path does not exist: %s", $projectPath));
+
+        return Command::FAILURE;
+    }
+
+    /**
+     * Show interactive project selection
+     */
+    private function selectProjectInteractively(ProjectService $projectService): int
+    {
+        $projects = $projectService->getProjects();
+        $currentProject = $projectService->getCurrentProject();
+
+        if (empty($projects)) {
+            $this->output->info("No projects registered. Use 'ctx project <path>' to add a project.");
+            return Command::SUCCESS;
+        }
+
+        // Show current project first
+        if ($currentProject !== null) {
+            $this->output->title("Current Project");
+            $this->output->text(\sprintf("Path: %s", $currentProject->path));
+
+            if ($currentProject->hasConfigFile()) {
+                $this->output->text(\sprintf("Config File: %s", $currentProject->getConfigFile()));
+            }
+
+            if ($currentProject->hasEnvFile()) {
+                $this->output->text(\sprintf("Env File: %s", $currentProject->getEnvFile()));
+            }
+
+            $aliases = $projectService->getAliasesForPath($currentProject->path);
+            if (!empty($aliases)) {
+                $this->output->text(\sprintf("Aliases: %s", \implode(', ', $aliases)));
+            }
+
+            $this->output->newLine();
+        }
+
+        // Build choice list with formatted options
+        $choices = [];
+        $choiceMap = []; // Maps display strings back to project paths
+        $i = 1;
+
+        foreach ($projects as $path => $info) {
+            $aliases = $projectService->getAliasesForPath($path);
+            $aliasString = !empty($aliases) ? ' [' . \implode(', ', $aliases) . ']' : '';
+            $isCurrent = ($currentProject && $currentProject->path === $path) ? ' (CURRENT)' : '';
+
+            $displayString = \sprintf(
+                "%d) %s%s%s",
+                $i++,
+                $path,
+                $aliasString,
+                $isCurrent,
+            );
+
+            $choices[] = $displayString;
+            $choiceMap[$displayString] = $path;
+        }
+
+        // Add option to cancel
+        $cancelOption = 'Cancel - keep current project';
+        $choices[] = $cancelOption;
+
+        // Create the question with all choices
+        $helper = $this->getHelper('question');
+        $question = new ChoiceQuestion(
+            'Select a project to switch to:',
+            $choices,
+            0, // Default to first option
+        );
+        $question->setErrorMessage('Invalid selection.');
+
+        $selectedChoice = $helper->ask($this->input, $this->output, $question);
+
+        // Handle cancel option
+        if ($selectedChoice === $cancelOption) {
+            $this->output->info('Operation cancelled. Current project unchanged.');
+            return Command::SUCCESS;
+        }
+
+        // Get the actual path from the selection
+        $selectedPath = $choiceMap[$selectedChoice];
+
+        // Switch to the selected project
+        if ($projectService->switchToProject($selectedPath)) {
+            $this->output->success(\sprintf("Switched to project: %s", $selectedPath));
+            return Command::SUCCESS;
+        }
+
+        // This should not happen as we're selecting from existing projects
+        $this->output->error('Failed to switch to selected project.');
+        return Command::FAILURE;
+    }
+
+    /**
+     * Normalize a path to an absolute path
+     */
+    private function normalizePath(string $path, DirectoriesInterface $dirs): string
+    {
+        // Handle special case for current directory
+        if ($path === '.') {
+            return (string) FSPath::cwd();
+        }
+
+        $pathObj = FSPath::create($path);
+
+        // If path is relative, make it absolute from the current directory
+        if ($pathObj->isRelative()) {
+            $pathObj = $pathObj->absolute();
+        }
+
+        return $pathObj->toString();
+    }
+}

--- a/src/McpServer/Projects/Console/ProjectListCommand.php
+++ b/src/McpServer/Projects/Console/ProjectListCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Console;
+
+use Butschster\ContextGenerator\Console\BaseCommand;
+use Butschster\ContextGenerator\Console\Renderer\Style;
+use Butschster\ContextGenerator\McpServer\Projects\ProjectService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+
+#[AsCommand(
+    name: 'project:list',
+    description: 'List all registered projects',
+    aliases: ['projects'],
+)]
+final class ProjectListCommand extends BaseCommand
+{
+    public function __invoke(ProjectService $projectService): int
+    {
+        $projects = $projectService->getProjects();
+        $aliases = $projectService->getAliases();
+        $currentProject = $projectService->getCurrentProject();
+
+        if (empty($projects)) {
+            $this->output->info("No projects registered. Use 'ctx project <path>' to add a project.");
+            return Command::SUCCESS;
+        }
+
+        $this->output->title("Registered Projects");
+
+        // Create inverse alias map for quick lookups
+        $pathToAliases = [];
+        foreach ($aliases as $alias => $path) {
+            if (!isset($pathToAliases[$path])) {
+                $pathToAliases[$path] = [];
+            }
+            $pathToAliases[$path][] = $alias;
+        }
+
+        // Create and configure table
+        $table = new Table($this->output);
+        $table->setHeaders(['Path', 'Config File', 'Env File', 'Aliases', 'Added', 'Current']);
+
+        // Add rows to table
+        foreach ($projects as $path => $info) {
+            $isCurrent = $currentProject && $currentProject->path === $path ? '✓' : '';
+
+            $aliasesStr = isset($pathToAliases[$path]) && !empty($pathToAliases[$path])
+                ? \implode(', ', $pathToAliases[$path])
+                : '';
+
+            $table->addRow([
+                Style::property($path),
+                $info->configFile ?? '',
+                $info->envFile ?? '',
+                $aliasesStr,
+                $info->addedAt ?? '',
+                $isCurrent ? Style::highlight($isCurrent) : '',
+            ]);
+        }
+
+        // Render table
+        $table->render();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/McpServer/Projects/DTO/CurrentProjectDTO.php
+++ b/src/McpServer/Projects/DTO/CurrentProjectDTO.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\DTO;
+
+use Butschster\ContextGenerator\Application\FSPath;
+
+/**
+ * Represents the currently active project
+ */
+final readonly class CurrentProjectDTO implements \JsonSerializable
+{
+    /**
+     * @param string $path Absolute path to the project directory
+     * @param string|null $configFile Path to custom configuration file within the project
+     * @param string|null $envFile Path to .env file within the project
+     */
+    public function __construct(
+        public string $path,
+        private ?string $configFile = null,
+        private ?string $envFile = null,
+    ) {}
+
+    /**
+     * Create from array data
+     */
+    public static function fromArray(?array $data): ?self
+    {
+        if ($data === null || empty($data['path'])) {
+            return null;
+        }
+
+        return new self(
+            path: $data['path'],
+            configFile: $data['config_file'] ?? null,
+            envFile: $data['env_file'] ?? null,
+        );
+    }
+
+    public function hasConfigFile(): bool
+    {
+        return $this->configFile !== null;
+    }
+
+    public function hasEnvFile(): bool
+    {
+        return $this->envFile !== null;
+    }
+
+    /**
+     * Get the configuration file path
+     */
+    public function getConfigFile(): ?string
+    {
+        if ($this->configFile === null) {
+            return null;
+        }
+
+        return (string) FSPath::create($this->path)->join($this->configFile);
+    }
+
+    /**
+     * Get the .env file path
+     */
+    public function getEnvFile(): ?string
+    {
+        if ($this->envFile === null) {
+            return null;
+        }
+
+        return (string) FSPath::create($this->path)->join($this->envFile);
+    }
+
+    /**
+     * Convert to array representation
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'path' => $this->path,
+            'config_file' => $this->configFile,
+            'env_file' => $this->envFile,
+        ];
+    }
+}

--- a/src/McpServer/Projects/DTO/ProjectDTO.php
+++ b/src/McpServer/Projects/DTO/ProjectDTO.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\DTO;
+
+/**
+ * Represents a single project configuration
+ */
+final readonly class ProjectDTO implements \JsonSerializable
+{
+    /**
+     * @param string $path Absolute path to the project directory
+     * @param string $addedAt Date when the project was added
+     * @param string|null $configFile Path to custom configuration file within the project
+     * @param string|null $envFile Path to .env file within the project
+     */
+    public function __construct(
+        public string $path,
+        public string $addedAt = '',
+        public ?string $configFile = null,
+        public ?string $envFile = null,
+    ) {}
+
+    /**
+     * Create from array data
+     */
+    public static function fromArray(string $path, array $data): self
+    {
+        return new self(
+            path: $path,
+            addedAt: $data['added_at'] ?? \date('Y-m-d H:i:s'),
+            configFile: $data['config_file'] ?? null,
+            envFile: $data['env_file'] ?? null,
+        );
+    }
+
+    /**
+     * Convert to array representation
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'added_at' => $this->addedAt,
+            'config_file' => $this->configFile,
+            'env_file' => $this->envFile,
+        ];
+    }
+}

--- a/src/McpServer/Projects/DTO/ProjectStateDTO.php
+++ b/src/McpServer/Projects/DTO/ProjectStateDTO.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\DTO;
+
+/**
+ * Contains the complete project state
+ */
+final class ProjectStateDTO implements \JsonSerializable
+{
+    /**
+     * @param CurrentProjectDTO|null $currentProject Currently active project
+     * @param array<string, ProjectDTO> $projects Collection of all projects indexed by path
+     * @param array<string, string> $aliases Project aliases mapping (alias => path)
+     */
+    public function __construct(
+        public ?CurrentProjectDTO $currentProject = null,
+        public array $projects = [],
+        public array $aliases = [],
+    ) {}
+
+    /**
+     * Create from array data (typically loaded from storage)
+     */
+    public static function fromArray(array $data): self
+    {
+        // Process current project
+        $currentProject = CurrentProjectDTO::fromArray($data['current_project'] ?? null);
+
+        // Process projects
+        $projects = [];
+        foreach ($data['projects'] ?? [] as $path => $projectData) {
+            $projects[$path] = ProjectDTO::fromArray($path, $projectData);
+        }
+
+        // Load aliases
+        $aliases = $data['aliases'] ?? [];
+
+        return new self(
+            currentProject: $currentProject,
+            projects: $projects,
+            aliases: $aliases,
+        );
+    }
+
+    /**
+     * Get aliases for a specific project path
+     *
+     * @return string[]
+     */
+    public function getAliasesForPath(string $projectPath): array
+    {
+        $result = [];
+
+        foreach ($this->aliases as $alias => $path) {
+            if ($path === $projectPath) {
+                $result[] = $alias;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Resolve a path or alias to the actual project path
+     */
+    public function resolvePathOrAlias(string $pathOrAlias): string
+    {
+        return $this->aliases[$pathOrAlias] ?? $pathOrAlias;
+    }
+
+    public function jsonSerialize(): array
+    {
+        $projects = [];
+        foreach ($this->projects as $path => $project) {
+            $projects[$path] = $project;
+        }
+
+        return [
+            'current_project' => $this->currentProject,
+            'projects' => $projects,
+            'aliases' => $this->aliases,
+        ];
+    }
+}

--- a/src/McpServer/Projects/McpProjectsBootloader.php
+++ b/src/McpServer/Projects/McpProjectsBootloader.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects;
+
+use Butschster\ContextGenerator\Application\Bootloader\ConsoleBootloader;
+use Butschster\ContextGenerator\McpServer\Projects\Console\ProjectAddCommand;
+use Butschster\ContextGenerator\McpServer\Projects\Console\ProjectCommand;
+use Butschster\ContextGenerator\McpServer\Projects\Console\ProjectListCommand;
+use Butschster\ContextGenerator\McpServer\Projects\Repository\ProjectStateRepository;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\DirectoriesInterface;
+use Spiral\Core\FactoryInterface;
+
+final class McpProjectsBootloader extends Bootloader
+{
+    #[\Override]
+    public function defineSingletons(): array
+    {
+        return [
+            ProjectStateRepository::class => static fn(
+                FactoryInterface $factory,
+                DirectoriesInterface $dirs,
+            ) => $factory->make(ProjectStateRepository::class, [
+                'stateDirectory' => $dirs->get('global-state'),
+            ]),
+            ProjectService::class => ProjectService::class,
+        ];
+    }
+
+    public function init(ConsoleBootloader $console): void
+    {
+        $console->addCommand(
+            ProjectCommand::class,
+            ProjectAddCommand::class,
+            ProjectListCommand::class,
+        );
+    }
+}

--- a/src/McpServer/Projects/ProjectService.php
+++ b/src/McpServer/Projects/ProjectService.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\McpServer\Projects\DTO\CurrentProjectDTO;
+use Butschster\ContextGenerator\McpServer\Projects\DTO\ProjectDTO;
+use Butschster\ContextGenerator\McpServer\Projects\DTO\ProjectStateDTO;
+use Butschster\ContextGenerator\McpServer\Projects\Repository\ProjectStateRepository;
+use Psr\Log\LoggerInterface;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Service for managing project state
+ */
+#[LoggerPrefix(prefix: 'projects')]
+final class ProjectService
+{
+    /**
+     * Project state cache
+     */
+    private ?ProjectStateDTO $state = null;
+
+    public function __construct(
+        private readonly FilesInterface $files,
+        private readonly LoggerInterface $logger,
+        private readonly ProjectStateRepository $repository,
+    ) {}
+
+    public function getCurrentProject(): ?CurrentProjectDTO
+    {
+        $state = $this->getState();
+        $currentProject = $state->currentProject;
+
+        if ($currentProject === null) {
+            return null;
+        }
+
+        // Verify the project path still exists
+        if (!$this->files->exists($currentProject->path)) {
+            return null;
+        }
+
+        return $currentProject;
+    }
+
+    public function setCurrentProject(
+        string $projectPath,
+        ?string $alias = null,
+        ?string $configFile = null,
+        ?string $envFile = null,
+    ): void {
+        $state = $this->getState();
+
+        // Set current project
+        $state->currentProject = new CurrentProjectDTO(
+            path: $projectPath,
+            configFile: $configFile,
+            envFile: $envFile,
+        );
+
+        // Register the alias if provided
+        if ($alias !== null) {
+            $state->aliases[$alias] = $projectPath;
+        }
+
+        // Add to projects list if not already there
+        if (!isset($state->projects[$projectPath])) {
+            $state->projects[$projectPath] = new ProjectDTO(
+                path: $projectPath,
+                addedAt: \date('Y-m-d H:i:s'),
+                configFile: $configFile,
+                envFile: $envFile,
+            );
+        } else {
+            // Update existing project if config file or env file provided
+            $existingProject = $state->projects[$projectPath];
+            $needsUpdate = ($configFile !== null && $existingProject->configFile !== $configFile) ||
+                ($envFile !== null && $existingProject->envFile !== $envFile);
+
+            if ($needsUpdate) {
+                $state->projects[$projectPath] = new ProjectDTO(
+                    path: $projectPath,
+                    addedAt: $existingProject->addedAt,
+                    configFile: $configFile ?? $existingProject->configFile,
+                    envFile: $envFile ?? $existingProject->envFile,
+                );
+            }
+        }
+
+        $this->saveState($state);
+    }
+
+    /**
+     * Switch to an existing project without modifying its configuration
+     * Used for switching between projects without overriding their states
+     *
+     * @param string $projectPath Absolute path to the project directory
+     * @return bool True if the project was found and switched to, false otherwise
+     */
+    public function switchToProject(string $projectPath): bool
+    {
+        $state = $this->getState();
+
+        // Check if project exists
+        if (!isset($state->projects[$projectPath])) {
+            return false;
+        }
+
+        // Get existing project details
+        $projectInfo = $state->projects[$projectPath];
+
+        // Switch to the project without changing its configuration
+        $state->currentProject = new CurrentProjectDTO(
+            path: $projectPath,
+            configFile: $projectInfo->configFile,
+            envFile: $projectInfo->envFile,
+        );
+
+        $this->saveState($state);
+        return true;
+    }
+
+    public function addProject(
+        string $projectPath,
+        ?string $alias = null,
+        ?string $configFile = null,
+        ?string $envFile = null,
+    ): void {
+        $state = $this->getState();
+
+        // Register the alias if provided
+        if ($alias !== null) {
+            $state->aliases[$alias] = $projectPath;
+        }
+
+        // Add to projects list if not already there
+        if (!isset($state->projects[$projectPath])) {
+            $state->projects[$projectPath] = new ProjectDTO(
+                path: $projectPath,
+                addedAt: \date('Y-m-d H:i:s'),
+                configFile: $configFile,
+                envFile: $envFile,
+            );
+        } else {
+            // Update existing project
+            $existingProject = $state->projects[$projectPath];
+            $state->projects[$projectPath] = new ProjectDTO(
+                path: $projectPath,
+                addedAt: $existingProject->addedAt,
+                configFile: $configFile ?? $existingProject->configFile,
+                envFile: $envFile ?? $existingProject->envFile,
+            );
+        }
+
+        // if current project is set and matches the new project path, update it
+        if ($this->getCurrentProject()?->path === $projectPath) {
+            $this->switchToProject($projectPath);
+        }
+
+        $this->saveState($state);
+    }
+
+    /**
+     * Get a list of all projects
+     *
+     * @return array<string, ProjectDTO>
+     */
+    public function getProjects(): array
+    {
+        return $this->getState()->projects;
+    }
+
+    /**
+     * Get all project aliases
+     *
+     * @return array<string, string> Alias to path mapping
+     */
+    public function getAliases(): array
+    {
+        return $this->getState()->aliases;
+    }
+
+    /**
+     * Get aliases for a specific project path
+     *
+     * @return string[]
+     */
+    public function getAliasesForPath(string $projectPath): array
+    {
+        return $this->getState()->getAliasesForPath($projectPath);
+    }
+
+    /**
+     * Resolve a path or alias to the actual project path
+     */
+    public function resolvePathOrAlias(string $pathOrAlias): string
+    {
+        return $this->getState()->resolvePathOrAlias($pathOrAlias);
+    }
+
+    /**
+     * Get the current project state, loading from storage if necessary
+     */
+    private function getState(): ProjectStateDTO
+    {
+        if ($this->state === null) {
+            $this->state = $this->repository->load();
+        }
+
+        return $this->state;
+    }
+
+    /**
+     * Save the project state to disk
+     */
+    private function saveState(ProjectStateDTO $state): void
+    {
+        $this->state = $state;
+        $this->repository->save($state);
+    }
+}

--- a/src/McpServer/Projects/Repository/ProjectStateRepository.php
+++ b/src/McpServer/Projects/Repository/ProjectStateRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Repository;
+
+use Butschster\ContextGenerator\Application\FSPath;
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\McpServer\Projects\DTO\ProjectStateDTO;
+use Psr\Log\LoggerInterface;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Repository for managing project state persistence
+ */
+#[LoggerPrefix(prefix: 'projects.repository')]
+final readonly class ProjectStateRepository
+{
+    /**
+     * File path for storing project state
+     */
+    private const string STATE_FILE = '.project-state.json';
+
+    public function __construct(
+        private FilesInterface $files,
+        private LoggerInterface $logger,
+        private string $stateDirectory,
+    ) {}
+
+    /**
+     * Load project state from storage
+     */
+    public function load(): ProjectStateDTO
+    {
+        $stateFile = $this->getStateFilePath();
+
+        if (!$this->files->exists($stateFile)) {
+            return new ProjectStateDTO();
+        }
+
+        try {
+            $content = $this->files->read($stateFile);
+            $stateArray = \json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+            if (!\is_array($stateArray)) {
+                throw new \RuntimeException('Invalid state file format');
+            }
+
+            return ProjectStateDTO::fromArray($stateArray);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to load project state', [
+                'error' => $e->getMessage(),
+                'file' => $stateFile,
+            ]);
+
+            // Return empty state on error
+            return new ProjectStateDTO();
+        }
+    }
+
+    /**
+     * Save project state to storage
+     */
+    public function save(ProjectStateDTO $state): bool
+    {
+        $stateFile = $this->getStateFilePath();
+
+        try {
+            $content = \json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+            $this->files->ensureDirectory(\dirname($stateFile));
+            $this->files->write($stateFile, $content);
+
+            return true;
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to save project state', [
+                'error' => $e->getMessage(),
+                'file' => $stateFile,
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
+     * Get the path to the state file
+     */
+    private function getStateFilePath(): string
+    {
+        return (string) FSPath::create($this->stateDirectory)->join(self::STATE_FILE);
+    }
+}

--- a/src/McpServer/context.yaml
+++ b/src/McpServer/context.yaml
@@ -39,3 +39,10 @@ documents:
           - ./Routing
           - ./Server.php
           - ./ServerFactory.php
+
+  - description: "MCP Server Projects"
+    outputPath: "mcp/projects.md"
+    sources:
+      - type: file
+        sourcePaths:
+          - ./Projects


### PR DESCRIPTION
This functionality allows users to work with multiple project, significantly improving the workflow for developers managing multiple codebases.

## Key Features

- **Multi-Project Registry**: Register and manage an unlimited number of projects
- **Project Aliases**: Create shortcut names for quick project switching
- **Configuration Persistence**: Each project maintains its own configuration and environment settings
- **Interactive Selection**: Choose projects through an intuitive CLI interface
- **Current Directory Support**: Easily set the current directory as an active project

## New Commands

- `ctx project:add` - Register a new project with optional alias and configuration
- `ctx project` - View current project or switch projects interactively
- `ctx project <path|alias>` - Switch to a specific project by path or alias
- `ctx project:list` - List all registered projects with details

## Implementation Details

- Project state is stored in a JSON file for persistence across sessions
- Projects can have custom configuration files and environment settings
- The MCP server automatically uses the current project's context when started
- Comprehensive validation ensures project paths and configurations are valid