### PR TITLE
Add Context7 Documentation Source

### DIFF
--- a/json-schema.json
+++ b/json-schema.json
@@ -685,7 +685,8 @@
             "git_diff",
             "tree",
             "mcp",
-            "composer"
+            "composer",
+            "docs"
           ],
           "description": "Type of content source"
         },
@@ -811,6 +812,18 @@
           },
           "then": {
             "$ref": "#/definitions/treeSource"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "docs"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/docsSource"
           }
         }
       ]
@@ -1344,6 +1357,49 @@
         }
       ],
       "description": "Configuration for rendering diffs"
+    },
+    "docsSource": {
+      "type": "object",
+      "description": "Source for documentation content",
+      "required": [
+        "type",
+        "library",
+        "topic"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "docs"
+          ],
+          "description": "Source type - docs"
+        },
+        "library": {
+          "type": "string",
+          "description": "Library identifier (e.g., \"laravel/docs\")"
+        },
+        "topic": {
+          "type": "string",
+          "description": "Topic to search for within the library"
+        },
+        "tokens": {
+          "type": "integer",
+          "default": 500,
+          "description": "Maximum token count to retrieve"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the source"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of tags for this source"
+        }
+      },
+      "additionalProperties": false
     },
     "treeSource": {
       "description": "Generates a hierarchical visualization of directory structures",

--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -23,6 +23,7 @@ use Butschster\ContextGenerator\Modifier\PhpDocs\PhpDocsModifierBootloader;
 use Butschster\ContextGenerator\Modifier\PhpSignature\PhpSignatureModifierBootloader;
 use Butschster\ContextGenerator\Modifier\Sanitizer\SanitizerModifierBootloader;
 use Butschster\ContextGenerator\Source\Composer\ComposerSourceBootloader;
+use Butschster\ContextGenerator\Source\Docs\DocsSourceBootloader;
 use Butschster\ContextGenerator\Source\File\FileSourceBootloader;
 use Butschster\ContextGenerator\Source\GitDiff\GitDiffSourceBootloader;
 use Butschster\ContextGenerator\Source\Github\GithubSourceBootloader;
@@ -73,6 +74,7 @@ class Kernel extends AbstractKernel
             GitDiffSourceBootloader::class,
             TreeSourceBootloader::class,
             McpSourceBootloader::class,
+            DocsSourceBootloader::class,
 
             // Modifiers
             PhpContentFilterBootloader::class,

--- a/src/McpServer/Action/Tools/Docs/DocsSearchAction.php
+++ b/src/McpServer/Action/Tools/Docs/DocsSearchAction.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Docs;
+
+use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
+use Butschster\ContextGenerator\McpServer\Attribute\InputSchema;
+use Butschster\ContextGenerator\McpServer\Attribute\Tool;
+use Butschster\ContextGenerator\McpServer\Routing\Attribute\Post;
+use Mcp\Types\CallToolResult;
+use Mcp\Types\TextContent;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+
+#[Tool(
+    name: 'docs-search',
+    description: 'Search for documentation libraries available. Use "context-request" tool to get the context documents.',
+)]
+#[InputSchema(
+    name: 'query',
+    type: 'string',
+    description: 'The search query to find documentation libraries',
+    required: true,
+)]
+final readonly class DocsSearchAction
+{
+    private const string CONTEXT7_SEARCH_URL = 'https://context7.com/api/v1/search';
+
+    public function __construct(
+        private LoggerInterface $logger,
+        private HttpClientInterface $httpClient,
+    ) {}
+
+    #[Post(path: '/tools/call/docs-search', name: 'tools.docs-search')]
+    public function __invoke(ServerRequestInterface $request): CallToolResult
+    {
+        $this->logger->info('Processing docs-search tool');
+
+        // Get params from the parsed body for POST requests
+        $parsedBody = $request->getParsedBody();
+        $query = \trim($parsedBody['query'] ?? '');
+
+        if (empty($query)) {
+            return new CallToolResult([
+                new TextContent(
+                    text: 'Error: Missing query parameter',
+                ),
+            ], isError: true);
+        }
+
+        try {
+            $url = self::CONTEXT7_SEARCH_URL . '?' . \http_build_query(['query' => $query]);
+
+            $this->logger->debug('Sending request to Context7 search API', [
+                'url' => $url,
+            ]);
+
+            $headers = [
+                'User-Agent' => 'CTX Bot',
+                'Accept' => 'application/json',
+            ];
+
+            $response = $this->httpClient->get($url, $headers);
+
+            if (!$response->isSuccess()) {
+                $statusCode = $response->getStatusCode();
+                $this->logger->error('Context7 search request failed', [
+                    'statusCode' => $statusCode,
+                ]);
+                return new CallToolResult([
+                    new TextContent(
+                        text: "Context7 search request failed with status code {$statusCode}",
+                    ),
+                ], isError: true);
+            }
+
+            $data = $response->getJson(true);
+
+            if (!isset($data['results']) || !\is_array($data['results'])) {
+                $this->logger->warning('Unexpected response format from Context7', [
+                    'response' => $data,
+                ]);
+                return new CallToolResult([
+                    new TextContent(
+                        text: 'Unexpected response format from Context7 search API',
+                    ),
+                ], isError: true);
+            }
+
+            // Limit the number of results if needed
+            $results = $data['results'];
+
+            $this->logger->info('Documentation libraries found', [
+                'count' => \count($results),
+                'query' => $query,
+            ]);
+
+            // Format the results for display
+            $formattedResults = \array_map(static fn(array $library) => [
+                'id' => $library['id'] ?? '',
+                'title' => $library['title'] ?? '',
+                'description' => $library['description'] ?? '',
+                'branch' => $library['branch'] ?? 'main',
+                'lastUpdateDate' => $library['lastUpdateDate'] ?? '',
+                'totalTokens' => $library['totalTokens'] ?? 0,
+                'totalPages' => $library['totalPages'] ?? 0,
+                'usage' => \sprintf(
+                    "Use in your context config: { type: 'docs', library: '%s', topic: 'your-topic' }",
+                    \ltrim($library['id'] ?? '', '/'),
+                ),
+            ], $results);
+
+            return new CallToolResult([
+                new TextContent(
+                    text: \json_encode([
+                        'count' => \count($formattedResults),
+                        'results' => $formattedResults,
+                    ], JSON_PRETTY_PRINT),
+                ),
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Error searching documentation libraries', [
+                'query' => $query,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return new CallToolResult([
+                new TextContent(
+                    text: 'Error: ' . $e->getMessage(),
+                ),
+            ], isError: true);
+        }
+    }
+}

--- a/src/McpServer/McpConfig.php
+++ b/src/McpServer/McpConfig.php
@@ -27,6 +27,9 @@ final class McpConfig extends InjectableConfig
         'prompt_operations' => [
             'enable' => true,
         ],
+        'docs_tools' => [
+            'enable' => true,
+        ],
         'custom_tools' => [
             'enable' => true,
             'max_runtime' => 30,
@@ -70,6 +73,11 @@ final class McpConfig extends InjectableConfig
     public function isPromptOperationsEnabled(): bool
     {
         return $this->config['prompt_operations']['enable'] ?? false;
+    }
+
+    public function isDocsToolsEnabled(): bool
+    {
+        return $this->config['docs_tools']['enable'] ?? true;
     }
 
     public function commonPromptsEnabled(): bool

--- a/src/McpServer/McpConfig.php
+++ b/src/McpServer/McpConfig.php
@@ -28,7 +28,7 @@ final class McpConfig extends InjectableConfig
             'enable' => true,
         ],
         'docs_tools' => [
-            'enable' => true,
+            'enable' => false,
         ],
         'custom_tools' => [
             'enable' => true,

--- a/src/McpServer/McpServerBootloader.php
+++ b/src/McpServer/McpServerBootloader.php
@@ -12,6 +12,7 @@ use Butschster\ContextGenerator\McpServer\Action\Prompts\ListPromptsAction;
 use Butschster\ContextGenerator\McpServer\Action\Prompts\ProjectStructurePromptAction;
 use Butschster\ContextGenerator\McpServer\Action\Resources\GetDocumentContentResourceAction;
 use Butschster\ContextGenerator\McpServer\Action\Resources\JsonSchemaResourceAction;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Docs\DocsSearchAction;
 use Butschster\ContextGenerator\McpServer\Action\Resources\ListResourcesAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Context\ContextAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Context\ContextGetAction;
@@ -80,6 +81,9 @@ final class McpServerBootloader extends Bootloader
                 'context_operations' => [
                     'enable' => (bool) $env->get('MCP_CONTEXT_OPERATIONS', !$isCommonProject),
                 ],
+                'docs_tools' => [
+                    'enable' => (bool) $env->get('MCP_DOCS_TOOLS_ENABLED', true),
+                ],
                 'prompt_operations' => [
                     'enable' => (bool) $env->get('MCP_PROMPT_OPERATIONS', false),
                 ],
@@ -88,7 +92,7 @@ final class McpServerBootloader extends Bootloader
                     'max_runtime' => (int) $env->get('MCP_TOOL_MAX_RUNTIME', 30),
                 ],
                 'common_prompts' => [
-                    'enable' =>  (bool) $env->get('MCP_COMMON_PROMPTS', true),
+                    'enable' => (bool) $env->get('MCP_COMMON_PROMPTS', true),
                 ],
             ],
         );
@@ -132,7 +136,6 @@ final class McpServerBootloader extends Bootloader
 
     private function actions(McpConfig $config): array
     {
-
         $actions = [
             // Prompts controllers
             GetPromptAction::class,
@@ -172,6 +175,12 @@ final class McpServerBootloader extends Bootloader
             ];
         }
 
+        if ($config->isDocsToolsEnabled()) {
+            $actions = [
+                ...$actions,
+                DocsSearchAction::class,
+            ];
+        }
         if ($config->isFileOperationsEnabled()) {
             $actions = [
                 ...$actions,

--- a/src/McpServer/McpServerBootloader.php
+++ b/src/McpServer/McpServerBootloader.php
@@ -82,7 +82,7 @@ final class McpServerBootloader extends Bootloader
                     'enable' => (bool) $env->get('MCP_CONTEXT_OPERATIONS', !$isCommonProject),
                 ],
                 'docs_tools' => [
-                    'enable' => (bool) $env->get('MCP_DOCS_TOOLS_ENABLED', true),
+                    'enable' => (bool) $env->get('MCP_DOCS_TOOLS_ENABLED', false),
                 ],
                 'prompt_operations' => [
                     'enable' => (bool) $env->get('MCP_PROMPT_OPERATIONS', false),

--- a/src/McpServer/context.yaml
+++ b/src/McpServer/context.yaml
@@ -30,6 +30,7 @@ documents:
       - type: file
         sourcePaths:
           - ./Tool
+          - ./Action/Tools
 
   - description: "MCP Server routing"
     outputPath: "mcp/routing.md"

--- a/src/Source/Docs/DocsSource.php
+++ b/src/Source/Docs/DocsSource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\Docs;
+
+use Butschster\ContextGenerator\Source\BaseSource;
+
+/**
+ * Source for retrieving documentation from Context7 service
+ */
+final class DocsSource extends BaseSource
+{
+    /**
+     * @param string $library Library identifier (e.g., "laravel/docs")
+     * @param string $topic Topic to search for within the library
+     * @param string $description Human-readable description
+     * @param int $tokens Maximum token count to retrieve
+     * @param array<non-empty-string> $tags
+     */
+    public function __construct(
+        public readonly string $library,
+        public readonly string $topic,
+        string $description = '',
+        public readonly int $tokens = 2000,
+        array $tags = [],
+    ) {
+        parent::__construct(description: $description, tags: $tags);
+    }
+
+    #[\Override]
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'type' => 'docs',
+            ...parent::jsonSerialize(),
+            'library' => $this->library,
+            'topic' => $this->topic,
+            'tokens' => $this->tokens,
+        ], static fn($value) => $value !== null && $value !== '' && $value !== []);
+    }
+}

--- a/src/Source/Docs/DocsSourceBootloader.php
+++ b/src/Source/Docs/DocsSourceBootloader.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\Docs;
+
+use Butschster\ContextGenerator\Application\Bootloader\HttpClientBootloader;
+use Butschster\ContextGenerator\Application\Bootloader\SourceFetcherBootloader;
+use Butschster\ContextGenerator\Application\Logger\HasPrefixLoggerInterface;
+use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
+use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+use Butschster\ContextGenerator\Source\Registry\SourceRegistryInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\FactoryInterface;
+
+final class DocsSourceBootloader extends Bootloader
+{
+    #[\Override]
+    public function defineDependencies(): array
+    {
+        return [HttpClientBootloader::class];
+    }
+
+    #[\Override]
+    public function defineSingletons(): array
+    {
+        return [
+            DocsSourceFetcher::class => static fn(
+                FactoryInterface $factory,
+                ContentBuilderFactory $builderFactory,
+                HttpClientInterface $httpClient,
+                VariableResolver $variables,
+                HasPrefixLoggerInterface $logger,
+            ): DocsSourceFetcher => $factory->make(DocsSourceFetcher::class, [
+                'defaultHeaders' => [
+                    'User-Agent' => 'CTX Bot',
+                    'Accept' => 'text/plain',
+                    'Accept-Language' => 'en-US,en;q=0.9',
+                ],
+            ]),
+        ];
+    }
+
+    public function init(
+        SourceFetcherBootloader $registry,
+        SourceRegistryInterface $sourceRegistry,
+        DocsSourceFactory $factory,
+    ): void {
+        $registry->register(DocsSourceFetcher::class);
+        $sourceRegistry->register($factory);
+    }
+}

--- a/src/Source/Docs/DocsSourceFactory.php
+++ b/src/Source/Docs/DocsSourceFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\Docs;
+
+use Butschster\ContextGenerator\Source\Registry\AbstractSourceFactory;
+
+/**
+ * Factory for creating DocsSource instances
+ */
+final readonly class DocsSourceFactory extends AbstractSourceFactory
+{
+    #[\Override]
+    public function getType(): string
+    {
+        return 'docs';
+    }
+
+    #[\Override]
+    public function create(array $config): DocsSource
+    {
+        $this->logger?->debug('Creating Docs source', [
+            'path' => $this->dirs->getRootPath(),
+            'config' => $config,
+        ]);
+
+        if (!isset($config['library']) || !\is_string($config['library'])) {
+            throw new \RuntimeException('Docs source must have a "library" string property');
+        }
+
+        if (!isset($config['topic']) || !\is_string($config['topic'])) {
+            throw new \RuntimeException('Docs source must have a "topic" string property');
+        }
+
+        $tokens = 2000;
+        if (isset($config['tokens']) && (\is_int($config['tokens']) || \is_string($config['tokens']))) {
+            $tokens = (int) $config['tokens'];
+        }
+
+        return new DocsSource(
+            library: $config['library'],
+            topic: $config['topic'],
+            description: $config['description'] ?? '',
+            tokens: $tokens,
+            tags: $config['tags'] ?? [],
+        );
+    }
+}

--- a/src/Source/Docs/DocsSourceFetcher.php
+++ b/src/Source/Docs/DocsSourceFetcher.php
@@ -40,7 +40,7 @@ final readonly class DocsSourceFetcher implements SourceFetcherInterface
     public function supports(SourceInterface $source): bool
     {
         $isSupported = $source instanceof DocsSource;
-        $this->logger?->debug('Checking if source is supported', [
+        $this->logger->debug('Checking if source is supported', [
             'sourceType' => $source::class,
             'isSupported' => $isSupported,
         ]);
@@ -51,13 +51,13 @@ final readonly class DocsSourceFetcher implements SourceFetcherInterface
     {
         if (!$source instanceof DocsSource) {
             $errorMessage = 'Source must be an instance of DocsSource';
-            $this->logger?->error($errorMessage, [
+            $this->logger->error($errorMessage, [
                 'sourceType' => $source::class,
             ]);
             throw new \InvalidArgumentException($errorMessage);
         }
 
-        $this->logger?->info('Fetching documentation from Context7', [
+        $this->logger->info('Fetching documentation from Context7', [
             'library' => $source->library,
             'topic' => $source->topic,
             'tokens' => $source->tokens,
@@ -82,9 +82,7 @@ final readonly class DocsSourceFetcher implements SourceFetcherInterface
                 $tokens,
             );
 
-            trap($url);
-
-            $this->logger?->debug('Sending HTTP request to Context7', [
+            $this->logger->debug('Sending HTTP request to Context7', [
                 'url' => $url,
                 'headers' => $this->defaultHeaders,
             ]);
@@ -95,7 +93,7 @@ final readonly class DocsSourceFetcher implements SourceFetcherInterface
             $statusCode = $response->getStatusCode();
 
             if (!$response->isSuccess()) {
-                $this->logger?->warning('Context7 request failed', [
+                $this->logger->warning('Context7 request failed', [
                     'url' => $url,
                     'statusCode' => $statusCode,
                 ]);
@@ -108,7 +106,7 @@ final readonly class DocsSourceFetcher implements SourceFetcherInterface
                 return $builder->build();
             }
 
-            $this->logger?->debug('Context7 request successful', [
+            $this->logger->debug('Context7 request successful', [
                 'url' => $url,
                 'statusCode' => $statusCode,
             ]);
@@ -117,7 +115,7 @@ final readonly class DocsSourceFetcher implements SourceFetcherInterface
             $content = $response->getBody();
             $contentLength = \strlen($content);
 
-            $this->logger?->debug('Received documentation content', [
+            $this->logger->debug('Received documentation content', [
                 'library' => $library,
                 'topic' => $topic,
                 'contentLength' => $contentLength,
@@ -136,7 +134,7 @@ final readonly class DocsSourceFetcher implements SourceFetcherInterface
             // Add the processed content to the builder
             $builder->addText($processedContent);
         } catch (\Throwable $e) {
-            $this->logger?->error('Error retrieving documentation from Context7', [
+            $this->logger->error('Error retrieving documentation from Context7', [
                 'library' => $source->library ?? 'unknown',
                 'topic' => $source->topic ?? 'unknown',
                 'error' => $e->getMessage(),
@@ -152,7 +150,7 @@ final readonly class DocsSourceFetcher implements SourceFetcherInterface
         }
 
         $content = $builder->build();
-        $this->logger?->info('Documentation content fetched successfully', [
+        $this->logger->info('Documentation content fetched successfully', [
             'contentLength' => \strlen($content),
         ]);
 

--- a/src/Source/Docs/DocsSourceFetcher.php
+++ b/src/Source/Docs/DocsSourceFetcher.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source\Docs;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
+use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
+use Butschster\ContextGenerator\Source\Fetcher\SourceFetcherInterface;
+use Butschster\ContextGenerator\Source\SourceInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Fetcher for Context7 documentation sources
+ * @implements SourceFetcherInterface<DocsSource>
+ */
+#[LoggerPrefix(prefix: 'docs-source')]
+final readonly class DocsSourceFetcher implements SourceFetcherInterface
+{
+    private const string CONTEXT7_BASE_URL = 'https://context7.com';
+
+    /**
+     * @param array<string, string> $defaultHeaders Default HTTP headers to use for all requests
+     */
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private VariableResolver $variableResolver,
+        private ContentBuilderFactory $builderFactory,
+        private LoggerInterface $logger,
+        private array $defaultHeaders = [
+            'User-Agent' => 'CTX Bot',
+            'Accept' => 'text/plain',
+            'Accept-Language' => 'en-US,en;q=0.9',
+        ],
+    ) {}
+
+    public function supports(SourceInterface $source): bool
+    {
+        $isSupported = $source instanceof DocsSource;
+        $this->logger?->debug('Checking if source is supported', [
+            'sourceType' => $source::class,
+            'isSupported' => $isSupported,
+        ]);
+        return $isSupported;
+    }
+
+    public function fetch(SourceInterface $source, ModifiersApplierInterface $modifiersApplier): string
+    {
+        if (!$source instanceof DocsSource) {
+            $errorMessage = 'Source must be an instance of DocsSource';
+            $this->logger?->error($errorMessage, [
+                'sourceType' => $source::class,
+            ]);
+            throw new \InvalidArgumentException($errorMessage);
+        }
+
+        $this->logger?->info('Fetching documentation from Context7', [
+            'library' => $source->library,
+            'topic' => $source->topic,
+            'tokens' => $source->tokens,
+        ]);
+
+        // Create builder
+        $builder = $this->builderFactory
+            ->create()
+            ->addDescription($this->variableResolver->resolve($source->getDescription()));
+
+        try {
+            $library = $this->variableResolver->resolve($source->library);
+            $topic = $this->variableResolver->resolve($source->topic);
+            $tokens = $source->tokens;
+
+            // Build the URL for Context7 API
+            $url = \sprintf(
+                '%s/%s/llms.txt?topic=%s&tokens=%d',
+                self::CONTEXT7_BASE_URL,
+                $library,
+                \rawurlencode($topic),
+                $tokens,
+            );
+
+            trap($url);
+
+            $this->logger?->debug('Sending HTTP request to Context7', [
+                'url' => $url,
+                'headers' => $this->defaultHeaders,
+            ]);
+
+            // Send the request
+            $requestHeaders = $this->variableResolver->resolve($this->defaultHeaders);
+            $response = $this->httpClient->get($url, $requestHeaders);
+            $statusCode = $response->getStatusCode();
+
+            if (!$response->isSuccess()) {
+                $this->logger?->warning('Context7 request failed', [
+                    'url' => $url,
+                    'statusCode' => $statusCode,
+                ]);
+
+                $builder
+                    ->addComment("Library: {$library}")
+                    ->addComment("Topic: {$topic}")
+                    ->addComment("Error: HTTP status code {$statusCode}")
+                    ->addSeparator();
+                return $builder->build();
+            }
+
+            $this->logger?->debug('Context7 request successful', [
+                'url' => $url,
+                'statusCode' => $statusCode,
+            ]);
+
+            // Get the response body
+            $content = $response->getBody();
+            $contentLength = \strlen($content);
+
+            $this->logger?->debug('Received documentation content', [
+                'library' => $library,
+                'topic' => $topic,
+                'contentLength' => $contentLength,
+            ]);
+
+            // Add metadata to the builder
+            $builder
+                ->addComment("Library: {$library}")
+                ->addComment("Topic: {$topic}")
+                ->addComment("Tokens: {$tokens}")
+                ->addSeparator();
+
+            // Apply modifiers to the content
+            $processedContent = $modifiersApplier->apply($content, $url);
+
+            // Add the processed content to the builder
+            $builder->addText($processedContent);
+        } catch (\Throwable $e) {
+            $this->logger?->error('Error retrieving documentation from Context7', [
+                'library' => $source->library ?? 'unknown',
+                'topic' => $source->topic ?? 'unknown',
+                'error' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+
+            $builder
+                ->addComment("Library: {$source->library}")
+                ->addComment("Topic: {$source->topic}")
+                ->addComment("Error: {$e->getMessage()}")
+                ->addSeparator();
+        }
+
+        $content = $builder->build();
+        $this->logger?->info('Documentation content fetched successfully', [
+            'contentLength' => \strlen($content),
+        ]);
+
+        // Return built content
+        return $content;
+    }
+}

--- a/src/Source/context.yaml
+++ b/src/Source/context.yaml
@@ -12,7 +12,7 @@ documents:
           - ../Fetcher
           - ../DocumentCompilerFactory.php
 
-  - description: Source Implementations - File
+  - description: '[source] File'
     outputPath: sources/file-source.md
     sources:
       - type: file
@@ -20,7 +20,7 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
-  - description: Source Implementations - GitHub
+  - description: '[source] GitHub'
     outputPath: sources/github-source.md
     sources:
       - type: file
@@ -31,7 +31,7 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
-  - description: Source Implementations - Gitlab
+  - description: '[source] Gitlab'
     outputPath: sources/gitlab-source.md
     sources:
       - type: file
@@ -42,7 +42,7 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
-  - description: Source Implementations - URL
+  - description: '[source] URL'
     outputPath: sources/url-source.md
     sources:
       - type: file
@@ -53,7 +53,17 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
-  - description: Source Implementations - Text
+  - description: '[source] Docs'
+    outputPath: sources/docs-source.md
+    sources:
+      - type: file
+        sourcePaths:
+          - ./Docs
+          - ../Lib/HttpClient/HttpClientInterface.php
+        filePattern: '*.php'
+        showTreeView: true
+
+  - description: '[source] Text'
     outputPath: sources/text-source.md
     sources:
       - type: file
@@ -61,7 +71,7 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
-  - description: Source Implementations - MCP
+  - description: '[source] MCP'
     outputPath: sources/mcp-source.md
     sources:
       - type: file
@@ -69,7 +79,7 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
-  - description: Source Implementations - Git Diff
+  - description: '[source] Git Diff'
     outputPath: sources/git-diff-source.md
     sources:
       - type: file
@@ -77,7 +87,7 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
-  - description: Source Implementations - Composer
+  - description: '[source] Composer'
     outputPath: sources/composer-source.md
     sources:
       - type: file
@@ -85,7 +95,7 @@ documents:
         filePattern: '*.php'
         showTreeView: true
 
-  - description: Source Implementations - Tree
+  - description: '[source] Tree'
     outputPath: sources/tree-source.md
     sources:
       - type: file


### PR DESCRIPTION
This PR adds a new `docs` source type that integrates with Context7 documentation service, allowing users to retrieve targeted documentation content based on library, topic, and token limits.

## Features
- New `docs` source type for accessing Context7 documentation
- Library/topic/token-based filtering for precise content retrieval
- Complete integration with existing modifier and content builder systems
- JSON schema validation for configuration files

## Example Usage
```yaml
sources:
  - type: docs
    library: "laravel/docs"
    topic: controller
    tokens: 600
    description: "Laravel controller documentation"
    tags: ["laravel", "docs"]
```

---

## Features
- New `docs-search` tool for discovering available documentation libraries
- Configuration options via `MCP_DOCS_TOOLS_ENABLED` environment variable

## Implementation Details
- Added `DocsSearchAction` to query Context7's search API (`https://context7.com/api/v1/search`)
- Extended `McpConfig` with docs tools configuration options
- Updated `McpServerBootloader` to conditionally register docs tools
- Created documentation showing search and retrieval workflows

## Benefits
- Enables AI assistants to find and retrieve relevant documentation on demand
- Complements the `docs` source type for static context generation
- Provides direct access to specialized documentation without storing it locally
- Supports efficient token usage through customizable token limits