### PR TITLE
Global Exclusion Pattern System

### DIFF
--- a/docs/example/config/exclude-config.yaml
+++ b/docs/example/config/exclude-config.yaml
@@ -1,0 +1,28 @@
+# Example configuration with exclusion patterns
+
+# Global exclusion patterns
+exclude:
+  # File patterns to exclude globally (glob patterns with wildcards)
+  patterns:
+    - "**/.env*"
+    - "**/config/secrets.yaml"
+    - "**/*.pem"
+    - "**/*.key"
+    - "**/id_rsa"
+    - "**/credentials.json"
+  
+  # Paths to exclude globally (exact directories or files)
+  paths:
+    - ".secrets/"
+    - "config/credentials/"
+    - "node_modules"
+    - "vendor"
+
+# Regular configuration continues
+documents:
+  - description: "Project Documentation"
+    outputPath: "docs/project.md"
+    sources:
+      - type: file
+        sourcePaths: 
+          - "src/"

--- a/json-schema.json
+++ b/json-schema.json
@@ -44,6 +44,26 @@
         "$ref": "#/definitions/prompt"
       }
     },
+    "exclude": {
+      "type": "object",
+      "description": "Global exclusion patterns for filtering files from being included in documents",
+      "properties": {
+        "patterns": {
+          "type": "array",
+          "description": "Glob patterns to exclude files globally (e.g., '**/.env*', '**/*.pem')",
+          "items": {
+            "type": "string"
+          }
+        },
+        "paths": {
+          "type": "array",
+          "description": "Specific paths to exclude globally (directories or files)",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "variables": {
       "type": "object",
       "description": "Custom variables to use throughout the configuration",
@@ -705,7 +725,7 @@
           }
         }
       },
-      "allOf": [
+      "anyOf": [
         {
           "if": {
             "properties": {

--- a/src/Application/Bootloader/ExcludeBootloader.php
+++ b/src/Application/Bootloader/ExcludeBootloader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Application\Bootloader;
+
+use Butschster\ContextGenerator\Config\Exclude\ExcludeParserPlugin;
+use Butschster\ContextGenerator\Config\Exclude\ExcludeRegistry;
+use Butschster\ContextGenerator\Config\Exclude\ExcludeRegistryInterface;
+use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Core\Attribute\Singleton;
+
+#[Singleton]
+final class ExcludeBootloader extends Bootloader
+{
+    #[\Override]
+    public function defineSingletons(): array
+    {
+        return [
+            ExcludeRegistryInterface::class => ExcludeRegistry::class,
+        ];
+    }
+
+    public function boot(ConfigLoaderBootloader $configLoader, ExcludeParserPlugin $excludeParser): void
+    {
+        // Register the exclude parser plugin
+        $configLoader->registerParserPlugin($excludeParser);
+    }
+}

--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -10,6 +10,7 @@ use Butschster\ContextGenerator\Application\Bootloader\ConfigurationBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\ConsoleBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\ContentRendererBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\CoreBootloader;
+use Butschster\ContextGenerator\Application\Bootloader\ExcludeBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\GithubClientBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\GitlabClientBootloader;
 use Butschster\ContextGenerator\Application\Bootloader\HttpClientBootloader;
@@ -58,9 +59,10 @@ class Kernel extends AbstractKernel
             GithubClientBootloader::class,
             ComposerClientBootloader::class,
             ConfigLoaderBootloader::class,
+            VariableBootloader::class,
+            ExcludeBootloader::class,
             ModifierBootloader::class,
             ContentRendererBootloader::class,
-            VariableBootloader::class,
             SourceFetcherBootloader::class,
             SourceRegistryBootloader::class,
 

--- a/src/Config/Exclude/AbstractExclusion.php
+++ b/src/Config/Exclude/AbstractExclusion.php
@@ -25,6 +25,11 @@ abstract readonly class AbstractExclusion implements ExclusionPatternInterface
     }
 
     /**
+     * Abstract method to check if a path matches this pattern
+     */
+    abstract public function matches(string $path): bool;
+
+    /**
      * Normalize a pattern for consistent comparison
      */
     protected function normalizePattern(string $pattern): string
@@ -32,11 +37,6 @@ abstract readonly class AbstractExclusion implements ExclusionPatternInterface
         $pattern = \preg_replace('#^\./#', '', $pattern);
 
         // Remove trailing slash
-        return \rtrim($pattern, '/');
+        return \rtrim((string) $pattern, '/');
     }
-
-    /**
-     * Abstract method to check if a path matches this pattern
-     */
-    abstract public function matches(string $path): bool;
 }

--- a/src/Config/Exclude/AbstractExclusion.php
+++ b/src/Config/Exclude/AbstractExclusion.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Exclude;
+
+/**
+ * Base class for all exclusion patterns
+ */
+abstract readonly class AbstractExclusion implements ExclusionPatternInterface
+{
+    /**
+     * @param string $pattern Exclusion pattern value
+     */
+    public function __construct(
+        protected string $pattern,
+    ) {}
+
+    /**
+     * Get the raw pattern string
+     */
+    public function getPattern(): string
+    {
+        return $this->pattern;
+    }
+
+    /**
+     * Normalize a pattern for consistent comparison
+     */
+    protected function normalizePattern(string $pattern): string
+    {
+        $pattern = \preg_replace('#^\./#', '', $pattern);
+
+        // Remove trailing slash
+        return \rtrim($pattern, '/');
+    }
+
+    /**
+     * Abstract method to check if a path matches this pattern
+     */
+    abstract public function matches(string $path): bool;
+}

--- a/src/Config/Exclude/ExcludeParserPlugin.php
+++ b/src/Config/Exclude/ExcludeParserPlugin.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Exclude;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\Config\Parser\ConfigParserPluginInterface;
+use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Parser plugin for the 'exclude' section in configuration
+ */
+final readonly class ExcludeParserPlugin implements ConfigParserPluginInterface
+{
+    public function __construct(
+        private ExcludeRegistryInterface $registry,
+        #[LoggerPrefix(prefix: 'exclude-parser')]
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    public function getConfigKey(): string
+    {
+        return 'exclude';
+    }
+
+    public function supports(array $config): bool
+    {
+        return isset($config['exclude']) && \is_array($config['exclude']);
+    }
+
+    public function parse(array $config, string $rootPath): ?RegistryInterface
+    {
+        if (!$this->supports($config)) {
+            return null;
+        }
+
+        $excludeConfig = $config['exclude'];
+
+        // Parse patterns
+        if (isset($excludeConfig['patterns']) && \is_array($excludeConfig['patterns'])) {
+            $this->parsePatterns($excludeConfig['patterns']);
+        }
+
+        // Parse paths
+        if (isset($excludeConfig['paths']) && \is_array($excludeConfig['paths'])) {
+            $this->parsePaths($excludeConfig['paths']);
+        }
+
+        $this->logger?->info('Parsed exclusion configuration', [
+            'patternCount' => \count($this->registry->getPatterns()),
+        ]);
+
+        return $this->registry;
+    }
+
+    public function updateConfig(array $config, string $rootPath): array
+    {
+        // We don't need to modify the config, just return it as is
+        return $config;
+    }
+
+    /**
+     * Parse glob pattern exclusions
+     */
+    private function parsePatterns(array $patterns): void
+    {
+        foreach ($patterns as $pattern) {
+            if (!\is_string($pattern) || empty($pattern)) {
+                $this->logger?->warning('Invalid exclusion pattern, skipping', [
+                    'pattern' => $pattern,
+                ]);
+                continue;
+            }
+
+            $this->registry->addPattern(new PatternExclusion($pattern));
+        }
+    }
+
+    /**
+     * Parse path exclusions
+     */
+    private function parsePaths(array $paths): void
+    {
+        foreach ($paths as $path) {
+            if (!\is_string($path) || empty($path)) {
+                $this->logger?->warning('Invalid exclusion path, skipping', [
+                    'path' => $path,
+                ]);
+                continue;
+            }
+
+            $this->registry->addPattern(new PathExclusion($path));
+        }
+    }
+}

--- a/src/Config/Exclude/ExcludeParserPlugin.php
+++ b/src/Config/Exclude/ExcludeParserPlugin.php
@@ -36,6 +36,7 @@ final readonly class ExcludeParserPlugin implements ConfigParserPluginInterface
             return null;
         }
 
+        \assert($this->registry instanceof RegistryInterface);
         $excludeConfig = $config['exclude'];
 
         // Parse patterns

--- a/src/Config/Exclude/ExcludeRegistry.php
+++ b/src/Config/Exclude/ExcludeRegistry.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Exclude;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\Config\Registry\RegistryInterface;
+use Psr\Log\LoggerInterface;
+use Spiral\Core\Attribute\Singleton;
+
+/**
+ * Registry for file exclusion patterns
+ *
+ * @implements RegistryInterface<ExclusionPatternInterface>
+ */
+#[Singleton]
+final class ExcludeRegistry implements ExcludeRegistryInterface, RegistryInterface
+{
+    /** @var array<ExclusionPatternInterface> */
+    private array $patterns = [];
+
+    public function __construct(
+        #[LoggerPrefix(prefix: 'exclude-registry')]
+        private readonly ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Add a new exclusion pattern
+     */
+    public function addPattern(ExclusionPatternInterface $pattern): self
+    {
+        $this->patterns[] = $pattern;
+
+        $this->logger?->debug('Added exclusion pattern', [
+            'pattern' => $pattern->getPattern(),
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Check if a path should be excluded
+     */
+    public function shouldExclude(string $path): bool
+    {
+        foreach ($this->patterns as $pattern) {
+            if ($pattern->matches($path)) {
+                $this->logger?->debug('Path excluded by pattern', [
+                    'path' => $path,
+                    'pattern' => $pattern->getPattern(),
+                ]);
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get all registered exclusion patterns
+     */
+    public function getPatterns(): array
+    {
+        return $this->patterns;
+    }
+
+    /**
+     * Get the registry type
+     */
+    public function getType(): string
+    {
+        return 'exclude';
+    }
+
+    /**
+     * Get all items in the registry
+     */
+    public function getItems(): array
+    {
+        return $this->patterns;
+    }
+
+    /**
+     * Make the registry iterable
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->patterns);
+    }
+
+    /**
+     * JSON serialization
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'patterns' => \array_map(
+                static fn(ExclusionPatternInterface $pattern) => $pattern->jsonSerialize(),
+                $this->patterns,
+            ),
+        ];
+    }
+}

--- a/src/Config/Exclude/ExcludeRegistryInterface.php
+++ b/src/Config/Exclude/ExcludeRegistryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Exclude;
+
+/**
+ * Interface for exclusion pattern registry
+ */
+interface ExcludeRegistryInterface
+{
+    /**
+     * Add an exclusion pattern
+     */
+    public function addPattern(ExclusionPatternInterface $pattern): self;
+
+    /**
+     * Check if a path should be excluded
+     */
+    public function shouldExclude(string $path): bool;
+
+    /**
+     * Get all registered exclusion patterns
+     *
+     * @return array<ExclusionPatternInterface>
+     */
+    public function getPatterns(): array;
+}

--- a/src/Config/Exclude/ExclusionPatternInterface.php
+++ b/src/Config/Exclude/ExclusionPatternInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Exclude;
+
+/**
+ * Interface for all exclusion patterns
+ */
+interface ExclusionPatternInterface extends \JsonSerializable
+{
+    /**
+     * Check if a path matches this exclusion pattern
+     */
+    public function matches(string $path): bool;
+
+    /**
+     * Get the raw pattern string
+     */
+    public function getPattern(): string;
+}

--- a/src/Config/Exclude/PathExclusion.php
+++ b/src/Config/Exclude/PathExclusion.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Exclude;
+
+/**
+ * Exact path exclusion pattern
+ *
+ * Excludes specific paths (directories or files)
+ */
+final readonly class PathExclusion extends AbstractExclusion
+{
+    private string $normalizedPattern;
+
+    public function __construct(string $pattern)
+    {
+        parent::__construct($pattern);
+        $this->normalizedPattern = $this->normalizePattern($pattern);
+    }
+
+    /**
+     * Check if a path matches this exclusion pattern
+     *
+     * A path matches if it's exactly the same as the pattern
+     * or if it's a file within the directory specified by the pattern
+     */
+    public function matches(string $path): bool
+    {
+        $normalizedPath = $this->normalizePattern($path);
+
+        return $normalizedPath === $this->normalizedPattern ||
+            \str_contains($normalizedPath, $this->normalizedPattern);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'pattern' => $this->pattern,
+        ];
+    }
+}

--- a/src/Config/Exclude/PatternExclusion.php
+++ b/src/Config/Exclude/PatternExclusion.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Config\Exclude;
+
+use Butschster\ContextGenerator\Config\Import\PathMatcher;
+
+/**
+ * Glob pattern exclusion pattern
+ *
+ * Excludes files and directories using glob patterns
+ * with wildcards like *, **, ?, and other glob syntax
+ */
+final readonly class PatternExclusion extends AbstractExclusion
+{
+    private PathMatcher $matcher;
+
+    public function __construct(string $pattern)
+    {
+        parent::__construct($pattern);
+        $this->matcher = new PathMatcher($pattern);
+    }
+
+    /**
+     * Check if a path matches this exclusion pattern
+     *
+     * Uses glob pattern matching via PathMatcher
+     */
+    public function matches(string $path): bool
+    {
+        return $this->matcher->isMatch($path);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'pattern' => $this->pattern,
+        ];
+    }
+}

--- a/src/Config/Import/PathMatcher.php
+++ b/src/Config/Import/PathMatcher.php
@@ -176,12 +176,12 @@ final readonly class PathMatcher
     {
         $availableModifiers = 'imsxuADUn';
 
-        if (preg_match('/^(.{3,}?)[' . $availableModifiers . ']*$/', $str, $m)) {
-            $start = substr($m[1], 0, 1);
-            $end = substr($m[1], -1);
+        if (\preg_match('/^(.{3,}?)[' . $availableModifiers . ']*$/', $str, $m)) {
+            $start = \substr($m[1], 0, 1);
+            $end = \substr($m[1], -1);
 
             if ($start === $end) {
-                return !preg_match('/[*?[:alnum:] \\\\]/', $start);
+                return !\preg_match('/[*?[:alnum:] \\\\]/', $start);
             }
 
             foreach ([['{', '}'], ['(', ')'], ['[', ']'], ['<', '>']] as $delimiters) {

--- a/src/Config/context.yaml
+++ b/src/Config/context.yaml
@@ -17,6 +17,13 @@ documents:
         sourcePaths:
           - ./Import
 
+  - description: Configuration Exclude
+    outputPath: core/config-exclude.md
+    sources:
+      - type: file
+        sourcePaths:
+          - ./Exclude
+
   - description: Configuration Parser
     outputPath: core/config-parser.md
     sources:

--- a/src/Source/Composer/ComposerSourceFetcher.php
+++ b/src/Source/Composer/ComposerSourceFetcher.php
@@ -28,9 +28,9 @@ final readonly class ComposerSourceFetcher implements SourceFetcherInterface
 
     public function __construct(
         private ComposerProviderInterface $provider,
+        SymfonyFinder $finder,
         private string $basePath = '.',
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
-        private FileTreeBuilder $treeBuilder = new FileTreeBuilder(),
         private VariableResolver $variableResolver = new VariableResolver(),
         #[LoggerPrefix(prefix: 'composer-source-fetcher')]
         private ?LoggerInterface $logger = null,
@@ -38,7 +38,7 @@ final readonly class ComposerSourceFetcher implements SourceFetcherInterface
         // Create a FileSourceFetcher to handle the actual file fetching
         $this->fileSourceFetcher = new FileSourceFetcher(
             basePath: $this->basePath,
-            finder: new SymfonyFinder($this->treeBuilder),
+            finder: $finder,
             builderFactory: $this->builderFactory,
             logger: $this->logger instanceof LoggerInterface ? $this->logger : new NullLogger(),
         );

--- a/src/Source/Composer/ComposerSourceFetcher.php
+++ b/src/Source/Composer/ComposerSourceFetcher.php
@@ -6,7 +6,6 @@ namespace Butschster\ContextGenerator\Source\Composer;
 
 use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
-use Butschster\ContextGenerator\Lib\TreeBuilder\FileTreeBuilder;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
 use Butschster\ContextGenerator\Source\Composer\Provider\ComposerProviderInterface;

--- a/src/Source/File/FileSourceBootloader.php
+++ b/src/Source/File/FileSourceBootloader.php
@@ -25,6 +25,7 @@ final class FileSourceBootloader extends Bootloader
                 HasPrefixLoggerInterface $logger,
             ): FileSourceFetcher => $factory->make(FileSourceFetcher::class, [
                 'basePath' => (string) $dirs->getRootPath(),
+                'finder' => $factory->make(SymfonyFinder::class),
             ]),
         ];
     }

--- a/src/Source/File/FileSourceFetcher.php
+++ b/src/Source/File/FileSourceFetcher.php
@@ -21,7 +21,7 @@ final readonly class FileSourceFetcher implements SourceFetcherInterface
 {
     public function __construct(
         private string $basePath,
-        private FinderInterface $finder = new SymfonyFinder(),
+        private FinderInterface $finder,
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
         #[LoggerPrefix(prefix: 'file-source')]
         private ?LoggerInterface $logger = null,

--- a/src/Source/File/SymfonyFinder.php
+++ b/src/Source/File/SymfonyFinder.php
@@ -10,6 +10,7 @@ use Butschster\ContextGenerator\Lib\Finder\FinderResult;
 use Butschster\ContextGenerator\Lib\TreeBuilder\FileTreeBuilder;
 use Butschster\ContextGenerator\Source\Fetcher\FilterableSourceInterface;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Implementation of FinderInterface using Symfony's Finder component
@@ -113,8 +114,6 @@ final readonly class SymfonyFinder implements FinderInterface
             $count = 0;
 
             foreach ($finder as $file) {
-                trap($file);
-
                 $limitedFiles[] = $file;
                 $count++;
 
@@ -133,7 +132,7 @@ final readonly class SymfonyFinder implements FinderInterface
         $files = [];
         foreach ($finder as $file) {
             // Skip files that would be excluded by path patterns
-            if ($this->shouldExcludeFile($file->getPathname())) {
+            if ($this->shouldExcludeFile($this->getPath($file, $basePath))) {
                 continue;
             }
 
@@ -161,7 +160,7 @@ final readonly class SymfonyFinder implements FinderInterface
 
         foreach ($finder as $file) {
             // Skip excluded files in tree view
-            if ($this->shouldExcludeFile($file->getPathname())) {
+            if ($this->shouldExcludeFile($this->getPath($file, $basePath))) {
                 continue;
             }
 
@@ -181,5 +180,14 @@ final readonly class SymfonyFinder implements FinderInterface
     private function shouldExcludeFile(string $filePath): bool
     {
         return $this->excludeRegistry->shouldExclude($filePath);
+    }
+
+    private function getPath(SplFileInfo|\SplFileInfo $file, string $basePath)
+    {
+        if ($file instanceof SplFileInfo) {
+            return $file->getRelativePathname();
+        }
+
+        return \ltrim(\str_replace($basePath, '', $file->getRealPath()), '/');
     }
 }

--- a/src/Source/Github/GithubFinder.php
+++ b/src/Source/Github/GithubFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Source\Github;
 
+use Butschster\ContextGenerator\Config\Exclude\ExcludeRegistryInterface;
 use Butschster\ContextGenerator\Lib\Finder\FinderInterface;
 use Butschster\ContextGenerator\Lib\Finder\FinderResult;
 use Butschster\ContextGenerator\Lib\GithubClient\GithubClientInterface;
@@ -16,6 +17,8 @@ use Butschster\ContextGenerator\Lib\PathFilter\PathFilter;
 use Butschster\ContextGenerator\Lib\TreeBuilder\FileTreeBuilder;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Source\Fetcher\FilterableSourceInterface;
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Psr\Log\LoggerInterface;
 
 /**
  * GitHub content finder implementation
@@ -36,8 +39,11 @@ final class GithubFinder implements FinderInterface
      */
     public function __construct(
         private readonly GithubClientInterface $githubClient,
+        private readonly ExcludeRegistryInterface $excludeRegistry,
         private readonly VariableResolver $variableResolver = new VariableResolver(),
         private readonly FileTreeBuilder $fileTreeBuilder = new FileTreeBuilder(),
+        #[LoggerPrefix(prefix: 'github-finder')]
+        private readonly ?LoggerInterface $logger = null,
     ) {}
 
     /**
@@ -75,10 +81,14 @@ final class GithubFinder implements FinderInterface
         $files = [];
         $this->buildResultStructure($filteredItems, $repository, $files);
 
+        // Apply content filters
         $files = (new ContentsFilter(
             contains: $source->contains(),
             notContains: $source->notContains(),
         ))->apply($files);
+
+        // Apply global exclusion registry
+        $files = $this->applyGlobalExclusions($files);
 
         /** @psalm-suppress InvalidArgument */
         $tree = \array_map(static fn(GithubFileInfo $file): string => $file->getRelativePathname(), $files);
@@ -100,6 +110,25 @@ final class GithubFinder implements FinderInterface
         }
 
         return $items;
+    }
+
+    /**
+     * Apply global exclusion patterns to filter files
+     */
+    private function applyGlobalExclusions(array $files): array
+    {
+        return \array_filter($files, function (GithubFileInfo $file): bool {
+            $path = $file->getRelativePathname();
+
+            if ($this->excludeRegistry->shouldExclude($path)) {
+                $this->logger?->debug('File excluded by global exclusion pattern', [
+                    'path' => $path,
+                ]);
+                return false;
+            }
+
+            return true;
+        });
     }
 
     /**

--- a/src/Source/Tree/TreeSourceFetcher.php
+++ b/src/Source/Tree/TreeSourceFetcher.php
@@ -20,8 +20,8 @@ final readonly class TreeSourceFetcher implements SourceFetcherInterface
 {
     public function __construct(
         private string $basePath,
+        private SymfonyFinder $finder,
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
-        private SymfonyFinder $finder = new SymfonyFinder(),
         #[LoggerPrefix(prefix: 'tree-source')]
         private ?LoggerInterface $logger = null,
     ) {}

--- a/src/Source/context.yaml
+++ b/src/Source/context.yaml
@@ -18,7 +18,6 @@ documents:
       - type: file
         sourcePaths: ./File
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] GitHub'
     outputPath: sources/github-source.md
@@ -29,7 +28,6 @@ documents:
           - ../Lib/GithubClient/GithubClientInterface.php
           - ../Lib/PathFilter
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] Gitlab'
     outputPath: sources/gitlab-source.md
@@ -40,7 +38,6 @@ documents:
           - ../Lib/GitlabClient/GitlabClientInterface.php
           - ../Lib/PathFilter
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] URL'
     outputPath: sources/url-source.md
@@ -51,7 +48,6 @@ documents:
           - ./Lib/Html
           - ../Lib/HttpClient/HttpClientInterface.php
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] Docs'
     outputPath: sources/docs-source.md
@@ -61,7 +57,6 @@ documents:
           - ./Docs
           - ../Lib/HttpClient/HttpClientInterface.php
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] Text'
     outputPath: sources/text-source.md
@@ -69,7 +64,6 @@ documents:
       - type: file
         sourcePaths: ./Text
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] MCP'
     outputPath: sources/mcp-source.md
@@ -77,7 +71,6 @@ documents:
       - type: file
         sourcePaths: ./MCP
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] Git Diff'
     outputPath: sources/git-diff-source.md
@@ -85,7 +78,6 @@ documents:
       - type: file
         sourcePaths: ./GitDiff
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] Composer'
     outputPath: sources/composer-source.md
@@ -93,7 +85,6 @@ documents:
       - type: file
         sourcePaths: ./Composer
         filePattern: '*.php'
-        showTreeView: true
 
   - description: '[source] Tree'
     outputPath: sources/tree-source.md
@@ -101,7 +92,6 @@ documents:
       - type: file
         sourcePaths: ./Tree
         filePattern: '*.php'
-        showTreeView: true
 
   - description: Source Tree builder
     outputPath: sources/tree-builder.md
@@ -109,7 +99,6 @@ documents:
       - type: file
         sourcePaths: ../Lib/TreeBuilder
         filePattern: '*.php'
-        showTreeView: true
 
   - description: Source Token counter
     outputPath: sources/token-counter.md
@@ -117,7 +106,6 @@ documents:
       - type: file
         sourcePaths: ../Lib/TokenCounter
         filePattern: '*.php'
-        showTreeView: true
 
   - description: Document source renderer
     outputPath: sources/source-renderer.md
@@ -125,4 +113,3 @@ documents:
       - type: file
         sourcePaths: ../Lib/Content
         filePattern: '*.php'
-        showTreeView: true

--- a/tests/fixtures/Console/GenerateCommand/FileSource/exclude-test.yaml
+++ b/tests/fixtures/Console/GenerateCommand/FileSource/exclude-test.yaml
@@ -1,0 +1,22 @@
+# Test configuration for exclusion patterns
+
+# Global exclusion patterns
+exclude:
+  # File patterns to exclude globally (glob patterns with wildcards)
+  patterns:
+    - "*.js"      # Exclude all JavaScript files
+    - "*.txt"     # Exclude all text files
+  
+  # Paths to exclude globally (exact directories or files)
+  paths:
+    - "nested"       # Exclude the nested directory
+
+documents:
+  - description: "Exclusion Test"
+    outputPath: "exclude-test.md"
+    sources:
+      - type: file
+        description: "Files with Exclusions"
+        sourcePaths: "./"
+        # This would normally include all files, but exclusions should filter them
+        filePattern: [ "*.php", "*.js", "*.txt" ]

--- a/tests/src/Feature/Console/GenerateCommand/CompilingResult.php
+++ b/tests/src/Feature/Console/GenerateCommand/CompilingResult.php
@@ -104,7 +104,7 @@ final readonly class CompilingResult
      * @param array $notContains Strings that should NOT be in the document
      * @return self For method chaining
      */
-    public function assertContext(string $document, array $contains, array $notContains = []): self
+    public function assertContext(string $document, array $contains = [], array $notContains = []): self
     {
         foreach ($this->result['result'] as $documentData) {
             if ($documentData['context_path'] === $document) {

--- a/tests/src/Feature/Console/GenerateCommand/ExcludeTest.php
+++ b/tests/src/Feature/Console/GenerateCommand/ExcludeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\GenerateCommand;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\Console\ConsoleTestCase;
+
+final class ExcludeTest extends ConsoleTestCase
+{
+    private string $outputDir;
+
+    /**
+     * Data provider for command variations
+     */
+    public static function commandsProvider(): \Generator
+    {
+        yield 'generate' => ['generate'];
+        yield 'build' => ['build'];
+        yield 'compile' => ['compile'];
+    }
+
+    /**
+     * Test that global exclusion patterns work correctly
+     */
+    #[Test]
+    #[DataProvider('commandsProvider')]
+    public function global_exclusion_patterns_should_work(string $command): void
+    {
+        $this
+            ->buildContext(
+                workDir: $this->outputDir,
+                configPath: $this->getFixturesDir('Console/GenerateCommand/FileSource/exclude-test.yaml'),
+                command: $command,
+            )
+            ->assertDocumentsCompiled()
+            // TestClass.php should be included
+            ->assertContext(
+                document: 'exclude-test.md',
+                contains: [
+                    'TestClass.php',
+                    'class TestClass',
+                ],
+            )
+            // JavaScript files should be excluded by pattern
+            ->assertContext(
+                document: 'exclude-test.md',
+                notContains: [
+                    'script.js',
+                    'function helloWorld',
+                ],
+            )
+            // Text files should be excluded by pattern
+            ->assertContext(
+                document: 'exclude-test.md',
+                notContains: [
+                    'sample.txt',
+                    'This is a sample text file',
+                ],
+            )
+            // Nested directory should be excluded by path
+            ->assertContext(
+                document: 'exclude-test.md',
+                notContains: [
+                    'NestedClass.php',
+                    'class NestedClass',
+                ],
+            );
+    }
+
+    /**
+     * Set up the test
+     */
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->outputDir = $this->createTempDir();
+    }
+
+    /**
+     * Helper method to build context
+     */
+    protected function buildContext(
+        string $workDir,
+        ?string $configPath = null,
+        ?string $inlineJson = null,
+        ?string $envFile = null,
+        string $command = 'generate',
+        bool $asJson = true,
+    ): CompilingResult {
+        return (new ContextBuilder($this->getConsole()))->build(
+            workDir: $workDir,
+            configPath: $configPath,
+            inlineJson: $inlineJson,
+            envFile: $envFile,
+            command: $command,
+            asJson: $asJson,
+        );
+    }
+}

--- a/tests/src/context.yaml
+++ b/tests/src/context.yaml
@@ -44,12 +44,12 @@ documents:
     sources:
       - type: file
         sourcePaths:
-          - Feature/Console/GenerateCommand/FileSourceTest.php
+          - Feature/Console
           - TestApp.php
           - TestCase.php
         showTreeView: true
 
       - type: file
         sourcePaths:
-          - ../fixtures/Console/GenerateCommand/FileSource
+          - ../fixtures/Console
         showTreeView: true

--- a/tests/src/context.yaml
+++ b/tests/src/context.yaml
@@ -44,12 +44,12 @@ documents:
     sources:
       - type: file
         sourcePaths:
-          - Feature/Console
+          - Feature/Console/GenerateCommand/FileSourceTest.php
           - TestApp.php
           - TestCase.php
         showTreeView: true
 
       - type: file
         sourcePaths:
-          - ../../../fixtures/Console
+          - ../fixtures/Console/GenerateCommand/FileSource
         showTreeView: true


### PR DESCRIPTION
This PR adds a global configuration option to exclude sensitive files from being included in any context document, with seamless integration of pattern-based exclusions.

## Features
- **Global Exclusion Configuration**: New `exclude` section in configuration files
- **Multiple Exclusion Types**:
  - **Pattern-based**: Glob patterns like `**/*.key`, `**/.env*`
  - **Path-based**: Exact path or directory exclusions like `node_modules`, `.secrets/`

## Example Configuration
```yaml
# Global exclusion patterns
exclude:
  # File patterns to exclude globally
  patterns:
    - "**/.env*"
    - "**/config/secrets.yaml"
    - "**/*.pem"
    - "**/*.key"
  
  # Paths to exclude globally
  paths:
    - ".secrets/"
    - "config/credentials/"
    - "node_modules"
    - "vendor"

# Regular configuration continues
documents:
  - description: "Project Documentation"
    outputPath: "docs/project.md"
    sources:
      - type: file
        sourcePaths: "src/"
```