### PR TITLE
Fix config path resolution duplication issue

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -87,6 +87,7 @@ final class GenerateCommand extends BaseCommand
                 scope: function (
                     DocumentCompiler $compiler,
                     ConfigurationProvider $configProvider,
+                    DirectoriesInterface $dirs,
                 ): int {
                     try {
                         // Get the appropriate loader based on options provided
@@ -95,7 +96,7 @@ final class GenerateCommand extends BaseCommand
                             $loader = $configProvider->fromString($this->inlineJson);
                         } elseif ($this->configPath !== null) {
                             $this->logger->info(\sprintf('Loading configuration from %s...', $this->configPath));
-                            $loader = $configProvider->fromPath($this->configPath);
+                            $loader = $configProvider->fromPath($dirs->getConfigPath()->toString());
                         } else {
                             $this->logger->info('Loading configuration from default location...');
                             $loader = $configProvider->fromDefaultLocation();

--- a/tests/src/Unit/Lib/Variable/VariableSystemEdgeCasesTest.php
+++ b/tests/src/Unit/Lib/Variable/VariableSystemEdgeCasesTest.php
@@ -113,7 +113,7 @@ class VariableSystemEdgeCasesTest extends TestCase
     public function it_should_handle_variables_with_special_characters_in_values(string $value): void
     {
         // Create a provider with values containing special characters
-        $specialCharsProvider = new class($value) implements VariableProviderInterface {
+        $specialCharsProvider = new readonly class($value) implements VariableProviderInterface {
             public function __construct(private readonly string $testValue) {}
 
             public function has(string $name): bool


### PR DESCRIPTION
The `GenerateCommand` was using the raw `$this->configPath` option value directly when calling `$configProvider->fromPath()`, instead of using the properly resolved path from the `DirectoriesInterface` which handles path resolution logic correctly.

Fixes: #221