### PR TITLE
🚀 Add Binary Path Detection and Improve Self-Update Functionality

### DIFF
--- a/src/Console/SelfUpdateCommand.php
+++ b/src/Console/SelfUpdateCommand.php
@@ -66,9 +66,8 @@ final class SelfUpdateCommand extends BaseCommand
     public function __invoke(Application $app, EnvironmentInterface $env, DirectoriesInterface $dirs): int
     {
         $this->output->title('CTX Self Update');
-        $storeLocation = \trim($this->storeLocation ?: $env->get('CTX_BINARY_PATH', (string) $dirs->getRootPath()));
+        $storeLocation = \trim($this->storeLocation ?: $env->get('CTX_BINARY_PATH', (string) $dirs->getBinaryPath()));
         $type = \trim($this->type ?: ($app->isBinary ? 'bin' : 'phar'));
-
 
         // Check if we have a valid store location
         if (empty($storeLocation)) {

--- a/src/Directories.php
+++ b/src/Directories.php
@@ -15,6 +15,7 @@ use Spiral\Core\Attribute\Singleton;
 #[Singleton]
 final readonly class Directories implements DirectoriesInterface
 {
+    private FSPath $binaryPathObj;
     private FSPath $rootPathObj;
     private FSPath $outputPathObj;
     private FSPath $configPathObj;
@@ -35,6 +36,7 @@ final readonly class Directories implements DirectoriesInterface
         public string $configPath,
         public string $jsonSchemaPath,
         public ?string $envFilePath = null,
+        public ?string $binaryPath = null,
     ) {
         // Ensure paths are not empty
         if ($rootPath === '') {
@@ -51,58 +53,43 @@ final readonly class Directories implements DirectoriesInterface
         }
 
         // Initialize FSPath objects
+        $this->binaryPathObj = FSPath::create($this->binaryPath ?? $this->resolveBinaryPath());
         $this->rootPathObj = FSPath::create($rootPath);
         $this->outputPathObj = FSPath::create($outputPath);
         $this->configPathObj = FSPath::create($configPath);
         $this->envFilePathObj = $envFilePath !== null ? FSPath::create($envFilePath) : null;
     }
 
-    /**
-     * Get the root path of the project
-     */
+    public function getBinaryPath(): FSPath
+    {
+        return $this->binaryPathObj;
+    }
+
     public function getRootPath(): FSPath
     {
         return $this->rootPathObj;
     }
 
-    /**
-     * Get the output path where compiled documents will be saved
-     */
     public function getOutputPath(): FSPath
     {
         return $this->outputPathObj;
     }
 
-    /**
-     * Get the path where configuration files are located
-     */
     public function getConfigPath(): FSPath
     {
         return $this->configPathObj;
     }
 
-    /**
-     * Get the JSON schema path
-     */
     public function getJsonSchemaPath(): string
     {
         return $this->jsonSchemaPath;
     }
 
-    /**
-     * Get the environment file path if set
-     */
     public function getEnvFilePath(): ?FSPath
     {
         return $this->envFilePathObj;
     }
 
-    /**
-     * Create a new instance with a different root path.
-     *
-     * @param string|null $rootPath The new root path or null to keep the current one
-     * @return self A new instance with the updated root path
-     */
     public function withRootPath(?string $rootPath): self
     {
         if ($rootPath === null) {
@@ -115,15 +102,10 @@ final readonly class Directories implements DirectoriesInterface
             configPath: $this->configPath,
             jsonSchemaPath: $this->jsonSchemaPath,
             envFilePath: $this->envFilePath,
+            binaryPath: $this->binaryPath,
         );
     }
 
-    /**
-     * Create a new instance with a different config path.
-     *
-     * @param string|null $configPath The new config path or null to keep the current one
-     * @return self A new instance with the updated config path
-     */
     public function withConfigPath(?string $configPath): self
     {
         if ($configPath === null) {
@@ -136,15 +118,10 @@ final readonly class Directories implements DirectoriesInterface
             configPath: $configPath,
             jsonSchemaPath: $this->jsonSchemaPath,
             envFilePath: $this->envFilePath,
+            binaryPath: $this->binaryPath,
         );
     }
 
-    /**
-     * Create a new instance with a different output path.
-     *
-     * @param string|null $outputPath The new output path or null to keep the current one
-     * @return self A new instance with the updated output path
-     */
     public function withOutputPath(?string $outputPath): self
     {
         if ($outputPath === null) {
@@ -157,15 +134,10 @@ final readonly class Directories implements DirectoriesInterface
             configPath: $this->configPath,
             jsonSchemaPath: $this->jsonSchemaPath,
             envFilePath: $this->envFilePath,
+            binaryPath: $this->binaryPath,
         );
     }
 
-    /**
-     * Create a new instance with an environment file path derived from the given filename.
-     *
-     * @param string|null $envFileName The environment filename or null to keep the current one
-     * @return self A new instance with the updated environment file path
-     */
     public function withEnvFile(?string $envFileName): self
     {
         if ($envFileName === null) {
@@ -180,19 +152,10 @@ final readonly class Directories implements DirectoriesInterface
             configPath: $this->configPath,
             jsonSchemaPath: $this->jsonSchemaPath,
             envFilePath: $envFilePath,
+            binaryPath: $this->binaryPath,
         );
     }
 
-    /**
-     * Determine the effective root path based on config file path.
-     *
-     * This method is used to adjust the root path when a specific configuration
-     * file is provided, making relative paths within that configuration work correctly.
-     *
-     * @param string|null $configPath The configuration file path or null
-     * @param string|null $inlineConfig Inline configuration content or null
-     * @return self A new instance with adjusted paths based on the config location
-     */
     public function determineRootPath(?string $configPath = null, ?string $inlineConfig = null): self
     {
         if ($configPath === null || $inlineConfig !== null) {
@@ -214,5 +177,25 @@ final readonly class Directories implements DirectoriesInterface
         }
 
         return $this;
+    }
+
+    private function resolveBinaryPath(): string
+    {
+        // Primary: Use argv[0] (most reliable for CLI)
+        if (isset($_SERVER['argv'][0])) {
+            return $_SERVER['argv'][0];
+        }
+
+        // Fallback 1: PHP_SELF
+        if (isset($_SERVER['PHP_SELF'])) {
+            return $_SERVER['PHP_SELF'];
+        }
+
+        // Fallback 2: SCRIPT_NAME
+        if (isset($_SERVER['SCRIPT_NAME'])) {
+            return $_SERVER['SCRIPT_NAME'];
+        }
+
+        throw new \RuntimeException('Unable to determine binary path');
     }
 }

--- a/src/DirectoriesInterface.php
+++ b/src/DirectoriesInterface.php
@@ -16,6 +16,11 @@ interface DirectoriesInterface
     /**
      * Get the root path of the project
      */
+    public function getBinaryPath(): FSPath;
+
+    /**
+     * Get the root path of the project
+     */
     public function getRootPath(): FSPath;
 
     /**


### PR DESCRIPTION
This PR enhances the CLI tool's ability to detect its own binary path and improves the self-update functionality. The changes enable proper updates for PHAR-packaged binaries and provide more reliable path detection across different environments.

Fixes #216 