### PR TITLE
Add File and URL Content Loading for Prompt Messages

### DIFF
--- a/src/Console/Renderer/Style.php
+++ b/src/Console/Renderer/Style.php
@@ -18,6 +18,14 @@ final class Style
     }
 
     /**
+     * Create a section header styled text
+     */
+    public static function section(string $text): string
+    {
+        return \sprintf('<fg=bright-blue;options=bold>%s</>', $text);
+    }
+
+    /**
      * Create a separator line
      */
     public static function separator(string $char = '-', int $length = 80): string
@@ -39,6 +47,14 @@ final class Style
     public static function label(string $text): string
     {
         return \sprintf('<fg=yellow>%s</>', $text);
+    }
+
+    /**
+     * Create a value styled text
+     */
+    public static function value(string $text): string
+    {
+        return \sprintf('<fg=bright-white>%s</>', $text);
     }
 
     /**
@@ -91,10 +107,142 @@ final class Style
     }
 
     /**
+     * Create info styled text
+     */
+    public static function info(string $text): string
+    {
+        return \sprintf('<fg=cyan>%s</>', $text);
+    }
+
+    /**
      * Create highlighted text
      */
     public static function highlight(string $text): string
     {
         return \sprintf('<fg=bright-green>%s</>', $text);
+    }
+
+    /**
+     * Create muted/dimmed text
+     */
+    public static function muted(string $text): string
+    {
+        return \sprintf('<fg=gray>%s</>', $text);
+    }
+
+    /**
+     * Create command styled text (for showing command names)
+     */
+    public static function command(string $text): string
+    {
+        return \sprintf('<fg=bright-cyan;options=bold>%s</>', $text);
+    }
+
+    /**
+     * Create a comment styled text
+     */
+    public static function comment(string $text): string
+    {
+        return \sprintf('<fg=gray>%s</>', $text);
+    }
+
+    /**
+     * Create a question styled text
+     */
+    public static function question(string $text): string
+    {
+        return \sprintf('<fg=bright-yellow>%s</>', $text);
+    }
+
+    /**
+     * Create a note styled text
+     */
+    public static function note(string $text): string
+    {
+        return \sprintf('<fg=blue>%s</>', $text);
+    }
+
+    /**
+     * Create a caution styled text
+     */
+    public static function caution(string $text): string
+    {
+        return \sprintf('<fg=bright-red>%s</>', $text);
+    }
+
+    /**
+     * Create bold text
+     */
+    public static function bold(string $text): string
+    {
+        return \sprintf('<options=bold>%s</>', $text);
+    }
+
+    /**
+     * Create italic text
+     */
+    public static function italic(string $text): string
+    {
+        return \sprintf('<options=italic>%s</>', $text);
+    }
+
+    /**
+     * Create underlined text
+     */
+    public static function underline(string $text): string
+    {
+        return \sprintf('<options=underscore>%s</>', $text);
+    }
+
+    /**
+     * Create a table-style key-value pair
+     */
+    public static function keyValue(string $key, string $value, int $keyWidth = 15): string
+    {
+        return \sprintf(
+            '%s: %s',
+            self::property(\str_pad($key, $keyWidth)),
+            self::value($value),
+        );
+    }
+
+    /**
+     * Create a bulleted list item
+     */
+    public static function bullet(string $text, string $bullet = '•'): string
+    {
+        return \sprintf('%s %s', self::muted($bullet), $text);
+    }
+
+    /**
+     * Create a numbered list item
+     */
+    public static function numbered(string $text, int $number): string
+    {
+        return \sprintf('%s. %s', self::count($number), $text);
+    }
+
+    /**
+     * Create a path styled text
+     */
+    public static function path(string $path): string
+    {
+        return \sprintf('<fg=bright-blue>%s</>', $path);
+    }
+
+    /**
+     * Create a file styled text
+     */
+    public static function file(string $filename): string
+    {
+        return \sprintf('<fg=bright-yellow>%s</>', $filename);
+    }
+
+    /**
+     * Create a URL styled text
+     */
+    public static function url(string $url): string
+    {
+        return \sprintf('<fg=blue;options=underscore>%s</>', $url);
     }
 }

--- a/src/McpServer/Prompt/Console/ShowPromptCommand.php
+++ b/src/McpServer/Prompt/Console/ShowPromptCommand.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Prompt\Console;
+
+use Butschster\ContextGenerator\Application\AppScope;
+use Butschster\ContextGenerator\Config\ConfigurationProvider;
+use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
+use Butschster\ContextGenerator\Console\BaseCommand;
+use Butschster\ContextGenerator\Console\Renderer\Style;
+use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\McpServer\Prompt\Extension\PromptDefinition;
+use Butschster\ContextGenerator\McpServer\Prompt\PromptProviderInterface;
+use Butschster\ContextGenerator\McpServer\Prompt\PromptType;
+use Mcp\Types\Prompt;
+use Spiral\Console\Attribute\Argument;
+use Spiral\Console\Attribute\Option;
+use Spiral\Core\Container;
+use Spiral\Core\Scope;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Helper\TableCellStyle;
+
+#[AsCommand(
+    name: 'prompt:show',
+    description: 'Show detailed information about a specific prompt',
+)]
+final class ShowPromptCommand extends BaseCommand
+{
+    #[Argument(
+        name: 'id',
+        description: 'The ID of the prompt to display',
+    )]
+    protected string $promptId;
+
+    #[Option(
+        name: 'config-file',
+        shortcut: 'c',
+        description: 'Path to configuration file (absolute or relative to current directory).',
+    )]
+    protected ?string $configPath = null;
+
+    #[Option(
+        name: 'with-messages',
+        shortcut: 'm',
+        description: 'Show the full message content',
+    )]
+    protected bool $withMessages = false;
+
+    #[Option(
+        name: 'with-extensions',
+        shortcut: 'e',
+        description: 'Show extension details',
+    )]
+    protected bool $withExtensions = false;
+
+    public function __invoke(Container $container, DirectoriesInterface $dirs): int
+    {
+        return $container->runScope(
+            bindings: new Scope(
+                name: AppScope::Compiler,
+                bindings: [
+                    DirectoriesInterface::class => $dirs->determineRootPath($this->configPath),
+                ],
+            ),
+            scope: function (
+                ConfigurationProvider $configProvider,
+                PromptProviderInterface $promptProvider,
+            ) {
+                try {
+                    // Get the appropriate loader based on options provided
+                    if ($this->configPath !== null) {
+                        $this->logger->info(\sprintf('Loading configuration from %s...', $this->configPath));
+                        $loader = $configProvider->fromPath($this->configPath);
+                    } else {
+                        $this->logger->info('Loading configuration from default location...');
+                        $loader = $configProvider->fromDefaultLocation();
+                    }
+                } catch (ConfigLoaderException $e) {
+                    $this->logger->error('Failed to load configuration', [
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    $this->output->error(\sprintf('Failed to load configuration: %s', $e->getMessage()));
+
+                    return Command::FAILURE;
+                }
+
+                // Load configuration to make sure all prompts are properly registered
+                $loader->load();
+
+                // Check if prompt exists
+                if (!$promptProvider->has($this->promptId)) {
+                    $this->output->error(\sprintf('Prompt with ID "%s" not found.', $this->promptId));
+
+                    // Suggest similar prompts
+                    $this->suggestSimilarPrompts($promptProvider);
+
+                    return Command::FAILURE;
+                }
+
+                // Get the prompt
+                $prompt = $promptProvider->get($this->promptId);
+
+                // Display prompt details
+                return $this->displayPromptDetails($prompt);
+            },
+        );
+    }
+
+    /**
+     * Displays detailed information about a prompt.
+     */
+    private function displayPromptDetails(PromptDefinition $prompt): int
+    {
+        $this->output->title(\sprintf('Prompt: %s', $prompt->id));
+
+        // Basic information table
+        $this->displayBasicInfo($prompt);
+
+        // Arguments table
+        if (!empty($prompt->prompt->arguments)) {
+            $this->displayArguments($prompt->prompt);
+        }
+
+        // Extensions
+        if ($this->withExtensions && !empty($prompt->extensions)) {
+            $this->displayExtensions($prompt);
+        }
+
+        // Messages
+        if ($this->withMessages && !empty($prompt->messages)) {
+            $this->displayMessages($prompt);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Displays basic prompt information.
+     */
+    private function displayBasicInfo(PromptDefinition $prompt): void
+    {
+        $this->output->writeln('');
+        $this->output->writeln(Style::section('Basic Information'));
+
+        $table = new Table($this->output);
+        $table->setStyle('box');
+
+        $rows = [
+            ['ID', $prompt->id],
+            ['Type', $this->formatPromptType($prompt->type)],
+        ];
+
+        if ($prompt->prompt->description !== null) {
+            $rows[] = ['Description', $prompt->prompt->description];
+        }
+
+        if (!empty($prompt->tags)) {
+            $rows[] = ['Tags', \implode(', ', $prompt->tags)];
+        }
+
+        $rows[] = ['Messages', \count($prompt->messages)];
+        $rows[] = ['Arguments', \count($prompt->prompt->arguments)];
+        $rows[] = ['Extensions', \count($prompt->extensions)];
+
+        foreach ($rows as $row) {
+            $table->addRow([
+                new TableCell($row[0], ['style' => new TableCellStyle(['fg' => 'yellow'])]),
+                $row[1],
+            ]);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * Displays prompt arguments.
+     */
+    private function displayArguments(Prompt $prompt): void
+    {
+        $this->output->writeln('');
+        $this->output->writeln(Style::section('Arguments'));
+
+        $table = new Table($this->output);
+        $table->setHeaders(['Name', 'Required', 'Description']);
+        $table->setStyle('box');
+
+        foreach ($prompt->arguments as $arg) {
+            $table->addRow([
+                new TableCell($arg->name, ['style' => new TableCellStyle(['fg' => 'cyan'])]),
+                $arg->required ? Style::success('Yes') : Style::muted('No'),
+                $arg->description ?? Style::muted('(no description)'),
+            ]);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * Displays prompt extensions.
+     */
+    private function displayExtensions(PromptDefinition $prompt): void
+    {
+        $this->output->writeln('');
+        $this->output->writeln(Style::section('Extensions'));
+
+        foreach ($prompt->extensions as $index => $extension) {
+            $this->output->writeln(
+                \sprintf('  %s. %s', $index + 1, Style::property('Template ID:') . ' ' . $extension->templateId),
+            );
+
+            if (!empty($extension->arguments)) {
+                $this->output->writeln('     ' . Style::property('Arguments:'));
+                foreach ($extension->arguments as $arg) {
+                    $this->output->writeln(\sprintf('       • %s: %s', Style::value($arg->name), $arg->value));
+                }
+            }
+
+            if ($index < \count($prompt->extensions) - 1) {
+                $this->output->writeln('');
+            }
+        }
+    }
+
+    /**
+     * Displays prompt messages.
+     */
+    private function displayMessages(PromptDefinition $prompt): void
+    {
+        $this->output->writeln('');
+        $this->output->writeln(Style::section('Messages'));
+
+        foreach ($prompt->messages as $index => $message) {
+            $this->output->writeln('');
+            $this->output->writeln(
+                \sprintf('  %s. %s', $index + 1, Style::property('Role:') . ' ' . Style::value($message->role->value)),
+            );
+
+            // Show content preview (first few lines)
+            $content = $message->content->text ?? '';
+            $lines = \explode("\n", $content);
+
+            $this->output->writeln('     ' . Style::property('Content:'));
+
+            // Show first 10 lines or all if less
+            $displayLines = \array_slice($lines, 0, 10);
+            foreach ($displayLines as $line) {
+                $this->output->writeln('       ' . Style::muted($line));
+            }
+
+            // Show truncation indicator if there are more lines
+            if (\count($lines) > 10) {
+                $this->output->writeln('       ' . Style::muted(\sprintf('... (%d more lines)', \count($lines) - 10)));
+            }
+
+            $this->output->writeln('');
+            $this->output->writeln('     ' . Style::property('Statistics:'));
+            $this->output->writeln(\sprintf('       • Lines: %s', Style::count(\count($lines))));
+            $this->output->writeln(\sprintf('       • Characters: %s', Style::count(\strlen($content))));
+            $this->output->writeln(\sprintf('       • Words: %s', Style::count(\str_word_count($content))));
+        }
+    }
+
+    /**
+     * Suggests similar prompts when the requested prompt is not found.
+     */
+    private function suggestSimilarPrompts(PromptProviderInterface $promptProvider): void
+    {
+        $allPrompts = $promptProvider->all();
+
+        if (empty($allPrompts)) {
+            $this->output->writeln('No prompts are available.');
+            return;
+        }
+
+        // Find prompts with similar IDs (simple string similarity)
+        $suggestions = [];
+        foreach ($allPrompts as $id => $prompt) {
+            $similarity = 0;
+            \similar_text($this->promptId, $id, $similarity);
+            if ($similarity > 30) { // 30% similarity threshold
+                $suggestions[] = ['id' => $id, 'similarity' => $similarity];
+            }
+        }
+
+        // Sort by similarity
+        \usort($suggestions, static fn($a, $b) => $b['similarity'] <=> $a['similarity']);
+
+        if (!empty($suggestions)) {
+            $this->output->writeln('');
+            $this->output->writeln('Did you mean one of these?');
+            foreach (\array_slice($suggestions, 0, 3) as $suggestion) {
+                $this->output->writeln(\sprintf('  • %s', Style::value($suggestion['id'])));
+            }
+        } else {
+            $this->output->writeln('');
+            $this->output->writeln('Available prompts:');
+            $promptIds = \array_keys($allPrompts);
+            \sort($promptIds);
+            foreach (\array_slice($promptIds, 0, 5) as $id) {
+                $this->output->writeln(\sprintf('  • %s', Style::value($id)));
+            }
+
+            if (\count($promptIds) > 5) {
+                $this->output->writeln(\sprintf('  ... and %d more', \count($promptIds) - 5));
+                $this->output->writeln('');
+                $this->output->writeln('Use ' . Style::command('prompts:list') . ' to see all available prompts.');
+            }
+        }
+    }
+
+    /**
+     * Formats the prompt type for display.
+     */
+    private function formatPromptType(PromptType $type): string
+    {
+        return match ($type) {
+            PromptType::Prompt => Style::success('Prompt'),
+            PromptType::Template => Style::info('Template'),
+        };
+    }
+}

--- a/src/McpServer/Prompt/Content/FileContentProvider.php
+++ b/src/McpServer/Prompt/Content/FileContentProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Prompt\Content;
+
+use Butschster\ContextGenerator\McpServer\Prompt\Exception\FileMessageContentException;
+
+/**
+ * Interface for loading content from various sources.
+ */
+interface FileContentProvider
+{
+    /**
+     * Checks if this provider can handle the given source.
+     */
+    public function canHandle(string $source): bool;
+
+    /**
+     * Loads content from the given source.
+     *
+     * @throws FileMessageContentException If content loading fails
+     */
+    public function load(string $source): string;
+}

--- a/src/McpServer/Prompt/Content/FileMessageContentLoader.php
+++ b/src/McpServer/Prompt/Content/FileMessageContentLoader.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Prompt\Content;
+
+use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
+use Butschster\ContextGenerator\McpServer\Prompt\Exception\FileMessageContentException;
+use Butschster\ContextGenerator\McpServer\Prompt\Exception\PromptParsingException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Loads message content from external files or URLs using the 'file' property.
+ */
+#[LoggerPrefix(prefix: 'prompt.file-loader')]
+final readonly class FileMessageContentLoader extends MessageContentLoader
+{
+    /**
+     * @param FileContentProvider[] $providers
+     */
+    public function __construct(
+        private LoggerInterface $logger,
+        private array $providers = [],
+    ) {}
+
+    public function canHandle(array $messageConfig): bool
+    {
+        return isset($messageConfig['file']) && \is_string($messageConfig['file']);
+    }
+
+    public function loadContent(array $messageConfig): string
+    {
+        $this->validateMessageConfig($messageConfig);
+
+        if (!isset($messageConfig['file']) || !\is_string($messageConfig['file'])) {
+            throw new PromptParsingException('Message must have a valid file property');
+        }
+
+        // Validate that both content and file are not specified
+        if (isset($messageConfig['content'])) {
+            throw new PromptParsingException('Message cannot have both content and file properties');
+        }
+
+        $filePath = $messageConfig['file'];
+
+        if (empty(\trim($filePath))) {
+            throw new PromptParsingException('File path cannot be empty');
+        }
+
+        // Find appropriate provider
+        $provider = $this->findProvider($filePath);
+
+        if ($provider === null) {
+            throw new PromptParsingException(
+                \sprintf('No suitable provider found for file source: %s', $filePath),
+            );
+        }
+
+        try {
+            $this->logger?->debug('Loading message content from file', [
+                'source' => $filePath,
+                'provider' => $provider::class,
+            ]);
+
+            $content = $provider->load($filePath);
+
+            $this->logger?->debug('Successfully loaded message content', [
+                'source' => $filePath,
+                'contentLength' => \strlen($content),
+            ]);
+
+            return $content;
+        } catch (FileMessageContentException $e) {
+            $this->logger?->error('Failed to load message content from file', [
+                'source' => $filePath,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new PromptParsingException(
+                \sprintf('Failed to load content from "%s": %s', $filePath, $e->getMessage()),
+                previous: $e,
+            );
+        }
+    }
+
+    /**
+     * Finds the appropriate provider for the given file path.
+     */
+    private function findProvider(string $filePath): ?FileContentProvider
+    {
+        // Try providers in order
+        foreach ($this->providers as $provider) {
+            if ($provider->canHandle($filePath)) {
+                return $provider;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/McpServer/Prompt/Content/LocalFileContentProvider.php
+++ b/src/McpServer/Prompt/Content/LocalFileContentProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Prompt\Content;
+
+use Butschster\ContextGenerator\Application\FSPath;
+use Butschster\ContextGenerator\McpServer\Prompt\Exception\FileMessageContentException;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Loads content from local files using FSPath for robust path handling.
+ */
+final readonly class LocalFileContentProvider implements FileContentProvider
+{
+    public function __construct(
+        private FilesInterface $files,
+        private FSPath $rootPath,
+    ) {}
+
+    public function canHandle(string $source): bool
+    {
+        // Handle local files (not URLs)
+        return !\filter_var($source, \FILTER_VALIDATE_URL);
+    }
+
+    public function load(string $source): string
+    {
+        $filePath = $this->resolveFilePath($source);
+
+        if (!$filePath->exists()) {
+            throw FileMessageContentException::fileNotFound($filePath->toString());
+        }
+
+        if (!$filePath->isFile()) {
+            throw FileMessageContentException::fileNotReadable($filePath->toString());
+        }
+
+        if (!\is_readable($filePath->toString())) {
+            throw FileMessageContentException::fileNotReadable($filePath->toString());
+        }
+
+        $content = $this->files->read($filePath->toString());
+
+        if (empty(\trim($content))) {
+            throw FileMessageContentException::emptyContent($source);
+        }
+
+        return $content;
+    }
+
+    /**
+     * Resolves the file path using FSPath for robust path handling.
+     */
+    private function resolveFilePath(string $source): FSPath
+    {
+        $sourcePath = FSPath::create($source);
+
+        // If absolute path, use as-is
+        if ($sourcePath->isAbsolute()) {
+            return $sourcePath;
+        }
+
+        // Resolve relative to root path
+        return $this->rootPath->join($source);
+    }
+}

--- a/src/McpServer/Prompt/Content/MessageContentLoader.php
+++ b/src/McpServer/Prompt/Content/MessageContentLoader.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Prompt\Content;
+
+use Butschster\ContextGenerator\McpServer\Prompt\Exception\PromptParsingException;
+
+/**
+ * Abstract base class for loading message content from different sources.
+ */
+abstract readonly class MessageContentLoader
+{
+    /**
+     * Checks if this loader can handle the given message configuration.
+     */
+    abstract public function canHandle(array $messageConfig): bool;
+
+    /**
+     * Loads the content for the message.
+     *
+     * @throws PromptParsingException If content loading fails
+     */
+    abstract public function loadContent(array $messageConfig): string;
+
+    /**
+     * Validates that the message configuration is valid for this loader.
+     *
+     * @throws PromptParsingException If the configuration is invalid
+     */
+    protected function validateMessageConfig(array $messageConfig): void
+    {
+        if (!isset($messageConfig['role']) || !\is_string($messageConfig['role'])) {
+            throw new PromptParsingException('Message must have a valid role');
+        }
+    }
+}

--- a/src/McpServer/Prompt/Content/TextMessageContentLoader.php
+++ b/src/McpServer/Prompt/Content/TextMessageContentLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Prompt\Content;
+
+use Butschster\ContextGenerator\McpServer\Prompt\Exception\PromptParsingException;
+
+/**
+ * Loads message content from the 'content' property (existing functionality).
+ */
+final readonly class TextMessageContentLoader extends MessageContentLoader
+{
+    public function canHandle(array $messageConfig): bool
+    {
+        return isset($messageConfig['content']) && \is_string($messageConfig['content']);
+    }
+
+    public function loadContent(array $messageConfig): string
+    {
+        $this->validateMessageConfig($messageConfig);
+
+        if (!isset($messageConfig['content']) || !\is_string($messageConfig['content'])) {
+            throw new PromptParsingException('Message must have a valid content property');
+        }
+
+        return $messageConfig['content'];
+    }
+}

--- a/src/McpServer/Prompt/Content/UrlFileContentProvider.php
+++ b/src/McpServer/Prompt/Content/UrlFileContentProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Prompt\Content;
+
+use Butschster\ContextGenerator\Lib\HttpClient\Exception\HttpException;
+use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
+use Butschster\ContextGenerator\McpServer\Prompt\Exception\FileMessageContentException;
+
+/**
+ * Loads content from HTTP/HTTPS URLs using the built-in HTTP client.
+ */
+final readonly class UrlFileContentProvider implements FileContentProvider
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+    ) {}
+
+    public function canHandle(string $source): bool
+    {
+        $url = \filter_var($source, \FILTER_VALIDATE_URL);
+
+        if ($url === false) {
+            return false;
+        }
+
+        $scheme = \parse_url($url, \PHP_URL_SCHEME);
+        return \in_array($scheme, ['http', 'https'], true);
+    }
+
+    public function load(string $source): string
+    {
+        if (!\filter_var($source, \FILTER_VALIDATE_URL)) {
+            throw FileMessageContentException::invalidUrl($source);
+        }
+
+        try {
+            $response = $this->httpClient->getWithRedirects($source, [
+                'User-Agent' => 'ContextGenerator/1.0',
+                'Accept' => 'text/plain, text/markdown, text/*, */*',
+            ]);
+
+            if (!$response->isSuccess()) {
+                throw FileMessageContentException::urlLoadFailed(
+                    $source,
+                    \sprintf('HTTP %d', $response->getStatusCode()),
+                );
+            }
+
+            $content = $response->getBody();
+
+            if (empty(\trim($content))) {
+                throw FileMessageContentException::emptyContent($source);
+            }
+
+            return $content;
+        } catch (HttpException $e) {
+            throw FileMessageContentException::urlLoadFailed($source, $e->getMessage());
+        }
+    }
+}

--- a/src/McpServer/Prompt/Exception/FileMessageContentException.php
+++ b/src/McpServer/Prompt/Exception/FileMessageContentException.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Prompt\Exception;
+
+/**
+ * Exception thrown when file or URL content loading fails.
+ */
+final class FileMessageContentException extends PromptParsingException
+{
+    public static function fileNotFound(string $filePath): self
+    {
+        return new self(\sprintf('File not found: %s', $filePath));
+    }
+
+    public static function fileNotReadable(string $filePath): self
+    {
+        return new self(\sprintf('File is not readable: %s', $filePath));
+    }
+
+    public static function urlLoadFailed(string $url, string $reason): self
+    {
+        return new self(\sprintf('Failed to load URL "%s": %s', $url, $reason));
+    }
+
+    public static function invalidUrl(string $url): self
+    {
+        return new self(\sprintf('Invalid URL: %s', $url));
+    }
+
+    public static function emptyContent(string $source): self
+    {
+        return new self(\sprintf('Content is empty: %s', $source));
+    }
+}

--- a/src/McpServer/Prompt/PromptParserPlugin.php
+++ b/src/McpServer/Prompt/PromptParserPlugin.php
@@ -21,7 +21,7 @@ final readonly class PromptParserPlugin implements ConfigParserPluginInterface
     public function __construct(
         private PromptRegistryInterface $promptRegistry,
         private TemplateResolver $templateResolver,
-        private PromptConfigFactory $promptFactory = new PromptConfigFactory(),
+        private PromptConfigFactory $promptFactory,
         private ?LoggerInterface $logger = null,
     ) {}
 


### PR DESCRIPTION
This PR introduces the ability to load prompt message content from external files and URLs, enabling cleaner configuration management and better organization of large or complex prompts.

## **Key Features**

### **File Loading Support**
- **Local Files**: Support for relative and absolute file paths with robust FSPath integration
- **Remote URLs**: HTTP/HTTPS URL support using the existing HTTP client infrastructure
- **Cross-platform**: Proper Windows/Unix path handling via FSPath
- **Error Handling**: Comprehensive error messages for missing files, network issues, and permission problems

### **Content Sources**
```yaml
messages:
  - role: system
    file: ./prompts/system.md          # Local file (relative to config)
  - role: user  
    file: https://company.com/user.txt # Remote URL
  - role: assistant
    content: "Inline content"          # Existing format (unchanged)
```