### PR TITLE
Add MCP Project Management Tools

### DIFF
--- a/src/McpServer/McpConfig.php
+++ b/src/McpServer/McpConfig.php
@@ -37,6 +37,9 @@ final class McpConfig extends InjectableConfig
         'git_operations' => [
             'enable' => true,
         ],
+        'project_operations' => [
+            'enable' => true,
+        ],
     ];
 
     public function getDocumentNameFormat(string $path, string $description, string $tags): string
@@ -96,5 +99,10 @@ final class McpConfig extends InjectableConfig
     public function isGitOperationsEnabled(): bool
     {
         return $this->config['git_operations']['enable'] ?? true;
+    }
+
+    public function isProjectOperationsEnabled(): bool
+    {
+        return $this->config['project_operations']['enable'] ?? true;
     }
 }

--- a/src/McpServer/McpServerBootloader.php
+++ b/src/McpServer/McpServerBootloader.php
@@ -32,6 +32,8 @@ use Butschster\ContextGenerator\McpServer\Action\Tools\ListToolsAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Prompts\GetPromptToolAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Prompts\ListPromptsToolAction;
 use Butschster\ContextGenerator\McpServer\Console\MCPServerCommand;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\ProjectsListToolAction;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\ProjectSwitchToolAction;
 use Butschster\ContextGenerator\McpServer\Projects\McpProjectsBootloader;
 use Butschster\ContextGenerator\McpServer\ProjectService\ProjectServiceInterface;
 use Butschster\ContextGenerator\McpServer\Prompt\McpPromptBootloader;
@@ -97,6 +99,9 @@ final class McpServerBootloader extends Bootloader
                 ],
                 'git_operations' => [
                     'enable' => (bool) $env->get('MCP_GIT_OPERATIONS', !$isCommonProject),
+                ],
+                'project_operations' => [
+                    'enable' => (bool) $env->get('MCP_PROJECT_OPERATIONS', true),
                 ],
             ],
         );
@@ -189,6 +194,7 @@ final class McpServerBootloader extends Bootloader
                 FetchLibraryDocsAction::class,
             ];
         }
+
         if ($config->isFileOperationsEnabled()) {
             $actions = [
                 ...$actions,
@@ -207,6 +213,14 @@ final class McpServerBootloader extends Bootloader
             if ($config->isFileWriteEnabled()) {
                 $actions[] = FileWriteAction::class;
             }
+        }
+
+        if ($config->isProjectOperationsEnabled()) {
+            $actions = [
+                ...$actions,
+                ProjectsListToolAction::class,
+                ProjectSwitchToolAction::class,
+            ];
         }
 
         if ($config->isGitOperationsEnabled()) {

--- a/src/McpServer/Projects/Actions/Dto/AliasResolutionResponse.php
+++ b/src/McpServer/Projects/Actions/Dto/AliasResolutionResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions\Dto;
+
+/**
+ * Response when alias resolution occurs
+ */
+final readonly class AliasResolutionResponse implements \JsonSerializable
+{
+    public function __construct(
+        public string $originalAlias,
+        public string $resolvedPath,
+    ) {}
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'original_alias' => $this->originalAlias,
+            'resolved_path' => $this->resolvedPath,
+        ];
+    }
+}

--- a/src/McpServer/Projects/Actions/Dto/CurrentProjectResponse.php
+++ b/src/McpServer/Projects/Actions/Dto/CurrentProjectResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions\Dto;
+
+/**
+ * Represents current project information in response
+ */
+final readonly class CurrentProjectResponse implements \JsonSerializable
+{
+    /**
+     * @param string[] $aliases
+     */
+    public function __construct(
+        public string $path,
+        public ?string $configFile,
+        public ?string $envFile,
+        public array $aliases,
+    ) {}
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'path' => $this->path,
+            'config_file' => $this->configFile,
+            'env_file' => $this->envFile,
+            'aliases' => $this->aliases,
+        ];
+    }
+}

--- a/src/McpServer/Projects/Actions/Dto/ProjectInfoResponse.php
+++ b/src/McpServer/Projects/Actions/Dto/ProjectInfoResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions\Dto;
+
+/**
+ * Represents a single project in the response
+ */
+final readonly class ProjectInfoResponse implements \JsonSerializable
+{
+    /**
+     * @param string[] $aliases
+     */
+    public function __construct(
+        public string $path,
+        public ?string $configFile,
+        public ?string $envFile,
+        public string $addedAt,
+        public array $aliases,
+        public bool $isCurrent,
+    ) {}
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'path' => $this->path,
+            'config_file' => $this->configFile,
+            'env_file' => $this->envFile,
+            'added_at' => $this->addedAt,
+            'aliases' => $this->aliases,
+            'is_current' => $this->isCurrent,
+        ];
+    }
+}

--- a/src/McpServer/Projects/Actions/Dto/ProjectListRequest.php
+++ b/src/McpServer/Projects/Actions/Dto/ProjectListRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions\Dto;
+
+final readonly class ProjectListRequest
+{
+    public function __construct(
+        // No parameters needed for listing projects
+    ) {}
+}

--- a/src/McpServer/Projects/Actions/Dto/ProjectSwitchRequest.php
+++ b/src/McpServer/Projects/Actions/Dto/ProjectSwitchRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions\Dto;
+
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+
+final readonly class ProjectSwitchRequest
+{
+    public function __construct(
+        #[Field(
+            description: 'Alias to the project to switch to. Should be project alias.',
+        )]
+        public string $alias,
+    ) {}
+}

--- a/src/McpServer/Projects/Actions/Dto/ProjectSwitchResponse.php
+++ b/src/McpServer/Projects/Actions/Dto/ProjectSwitchResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions\Dto;
+
+/**
+ * Response for project switch tool
+ */
+final readonly class ProjectSwitchResponse implements \JsonSerializable
+{
+    public function __construct(
+        public bool $success,
+        public string $message,
+        public ?CurrentProjectResponse $currentProject = null,
+        public ?AliasResolutionResponse $resolvedFromAlias = null,
+    ) {}
+
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'success' => $this->success,
+            'message' => $this->message,
+            'current_project' => $this->currentProject,
+            'resolved_from_alias' => $this->resolvedFromAlias,
+        ], static fn($value) => $value !== null);
+    }
+}

--- a/src/McpServer/Projects/Actions/Dto/ProjectsListResponse.php
+++ b/src/McpServer/Projects/Actions/Dto/ProjectsListResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions\Dto;
+
+/**
+ * Response for projects list tool
+ */
+final readonly class ProjectsListResponse implements \JsonSerializable
+{
+    /**
+     * @param ProjectInfoResponse[] $projects
+     */
+    public function __construct(
+        public array $projects,
+        public ?CurrentProjectResponse $currentProject,
+        public int $totalProjects,
+        public ?string $message = null,
+    ) {}
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'projects' => $this->projects,
+            'current_project' => $this->currentProject,
+            'total_projects' => $this->totalProjects,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/src/McpServer/Projects/Actions/ProjectSwitchToolAction.php
+++ b/src/McpServer/Projects/Actions/ProjectSwitchToolAction.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions;
+
+use Butschster\ContextGenerator\Application\FSPath;
+use Butschster\ContextGenerator\McpServer\Attribute\InputSchema;
+use Butschster\ContextGenerator\McpServer\Attribute\Tool;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\Dto\AliasResolutionResponse;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\Dto\CurrentProjectResponse;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\Dto\ProjectSwitchRequest;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\Dto\ProjectSwitchResponse;
+use Butschster\ContextGenerator\McpServer\Projects\ProjectServiceInterface;
+use Butschster\ContextGenerator\McpServer\Routing\Attribute\Post;
+use Mcp\Types\CallToolResult;
+use Mcp\Types\TextContent;
+use Psr\Log\LoggerInterface;
+
+#[Tool(
+    name: 'project-switch',
+    description: 'Switch to a different project by path or alias',
+    title: 'Project Switch',
+)]
+#[InputSchema(class: ProjectSwitchRequest::class)]
+final readonly class ProjectSwitchToolAction
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private ProjectServiceInterface $projectService,
+    ) {}
+
+    #[Post(path: '/tools/call/project-switch', name: 'tools.project-switch')]
+    public function __invoke(ProjectSwitchRequest $request): CallToolResult
+    {
+        $this->logger->info('Processing project-switch tool', [
+            'pathOrAlias' => $request->pathOrAlias,
+        ]);
+
+        try {
+            $pathOrAlias = $request->pathOrAlias;
+
+            if (empty($pathOrAlias)) {
+                return new CallToolResult([
+                    new TextContent(text: 'Error: Missing pathOrAlias parameter'),
+                ], isError: true);
+            }
+
+            // Handle using an alias as the path
+            $resolvedPath = $this->projectService->resolvePathOrAlias($pathOrAlias);
+            $wasAlias = $resolvedPath !== $pathOrAlias;
+
+            // Normalize path to absolute path
+            $projectPath = $this->normalizePath($resolvedPath);
+
+            // Check if the project exists in our registry
+            $projects = $this->projectService->getProjects();
+            if (!isset($projects[$projectPath])) {
+                $availableProjects = \array_keys($projects);
+                $availableAliases = \array_keys($this->projectService->getAliases());
+
+                $suggestions = [];
+                if (!empty($availableProjects)) {
+                    $suggestions[] = 'Available project paths: ' . \implode(', ', $availableProjects);
+                }
+                if (!empty($availableAliases)) {
+                    $suggestions[] = 'Available aliases: ' . \implode(', ', $availableAliases);
+                }
+
+                return new CallToolResult([
+                    new TextContent(
+                        text: \sprintf(
+                            "Error: Project '%s' is not registered.\n%s",
+                            $projectPath,
+                            \implode("\n", $suggestions),
+                        ),
+                    ),
+                ], isError: true);
+            }
+
+            // Try to switch to this project
+            if ($this->projectService->switchToProject($projectPath)) {
+                $currentProject = $this->projectService->getCurrentProject();
+                $aliases = $this->projectService->getAliasesForPath($projectPath);
+
+                $currentProjectResponse = new CurrentProjectResponse(
+                    path: $currentProject->path,
+                    configFile: $currentProject->hasConfigFile() ? $currentProject->getConfigFile() : null,
+                    envFile: $currentProject->hasEnvFile() ? $currentProject->getEnvFile() : null,
+                    aliases: $aliases,
+                );
+
+                $aliasResolution = null;
+                if ($wasAlias) {
+                    $aliasResolution = new AliasResolutionResponse(
+                        originalAlias: $pathOrAlias,
+                        resolvedPath: $projectPath,
+                    );
+                }
+
+                $response = new ProjectSwitchResponse(
+                    success: true,
+                    message: \sprintf('Successfully switched to project: %s', $projectPath),
+                    currentProject: $currentProjectResponse,
+                    resolvedFromAlias: $aliasResolution,
+                );
+
+                return new CallToolResult([
+                    new TextContent(text: \json_encode($response, JSON_PRETTY_PRINT)),
+                ]);
+            }
+
+            $response = new ProjectSwitchResponse(
+                success: false,
+                message: \sprintf("Failed to switch to project '%s'", $projectPath),
+            );
+
+            return new CallToolResult([
+                new TextContent(text: \json_encode($response, JSON_PRETTY_PRINT)),
+            ], isError: true);
+        } catch (\Throwable $e) {
+            $this->logger->error('Error switching project', [
+                'pathOrAlias' => $request->pathOrAlias,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return new CallToolResult([
+                new TextContent(text: 'Error: ' . $e->getMessage()),
+            ], isError: true);
+        }
+    }
+
+    /**
+     * Normalize a path to an absolute path
+     */
+    private function normalizePath(string $path): string
+    {
+        // Handle special case for current directory
+        if ($path === '.') {
+            return (string) FSPath::cwd();
+        }
+
+        $pathObj = FSPath::create($path);
+
+        // If path is relative, make it absolute from the current directory
+        if ($pathObj->isRelative()) {
+            $pathObj = $pathObj->absolute();
+        }
+
+        return $pathObj->toString();
+    }
+}

--- a/src/McpServer/Projects/Actions/ProjectSwitchToolAction.php
+++ b/src/McpServer/Projects/Actions/ProjectSwitchToolAction.php
@@ -34,11 +34,11 @@ final readonly class ProjectSwitchToolAction
     public function __invoke(ProjectSwitchRequest $request): CallToolResult
     {
         $this->logger->info('Processing project-switch tool', [
-            'pathOrAlias' => $request->pathOrAlias,
+            'pathOrAlias' => $request->alias,
         ]);
 
         try {
-            $pathOrAlias = $request->pathOrAlias;
+            $pathOrAlias = $request->alias;
 
             if (empty($pathOrAlias)) {
                 return new CallToolResult([
@@ -120,7 +120,7 @@ final readonly class ProjectSwitchToolAction
             ], isError: true);
         } catch (\Throwable $e) {
             $this->logger->error('Error switching project', [
-                'pathOrAlias' => $request->pathOrAlias,
+                'pathOrAlias' => $request->alias,
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
             ]);

--- a/src/McpServer/Projects/Actions/ProjectsListToolAction.php
+++ b/src/McpServer/Projects/Actions/ProjectsListToolAction.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Projects\Actions;
+
+use Butschster\ContextGenerator\McpServer\Attribute\InputSchema;
+use Butschster\ContextGenerator\McpServer\Attribute\Tool;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\Dto\CurrentProjectResponse;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\Dto\ProjectInfoResponse;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\Dto\ProjectListRequest;
+use Butschster\ContextGenerator\McpServer\Projects\Actions\Dto\ProjectsListResponse;
+use Butschster\ContextGenerator\McpServer\Projects\ProjectServiceInterface;
+use Butschster\ContextGenerator\McpServer\Routing\Attribute\Post;
+use Mcp\Types\CallToolResult;
+use Mcp\Types\TextContent;
+use Psr\Log\LoggerInterface;
+
+#[Tool(
+    name: 'projects-list',
+    description: 'List all registered projects with their paths, aliases, and configuration details',
+    title: 'Projects List',
+)]
+#[InputSchema(class: ProjectListRequest::class)]
+final readonly class ProjectsListToolAction
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private ProjectServiceInterface $projectService,
+    ) {}
+
+    #[Post(path: '/tools/call/projects-list', name: 'tools.projects-list')]
+    public function __invoke(ProjectListRequest $request): CallToolResult
+    {
+        $this->logger->info('Processing projects-list tool');
+
+        try {
+            $projects = $this->projectService->getProjects();
+            $aliases = $this->projectService->getAliases();
+            $currentProject = $this->projectService->getCurrentProject();
+
+            if (empty($projects)) {
+                $response = new ProjectsListResponse(
+                    projects: [],
+                    currentProject: null,
+                    totalProjects: 0,
+                    message: 'No projects registered. Use project:add command to add projects.',
+                );
+
+                return new CallToolResult([
+                    new TextContent(text: \json_encode($response, JSON_PRETTY_PRINT)),
+                ]);
+            }
+
+            // Create inverse alias map for quick lookups
+            $pathToAliases = [];
+            foreach ($aliases as $alias => $path) {
+                if (!isset($pathToAliases[$path])) {
+                    $pathToAliases[$path] = [];
+                }
+                $pathToAliases[$path][] = $alias;
+            }
+
+            // Build project info responses
+            $projectInfos = [];
+            foreach ($projects as $path => $info) {
+                $projectInfos[] = new ProjectInfoResponse(
+                    path: $path,
+                    configFile: $info->configFile,
+                    envFile: $info->envFile,
+                    addedAt: $info->addedAt,
+                    aliases: $pathToAliases[$path] ?? [],
+                    isCurrent: $currentProject && $currentProject->path === $path,
+                );
+            }
+
+            // Build current project response
+            $currentProjectResponse = null;
+            if ($currentProject !== null) {
+                $currentProjectResponse = new CurrentProjectResponse(
+                    path: $currentProject->path,
+                    configFile: $currentProject->hasConfigFile() ? $currentProject->getConfigFile() : null,
+                    envFile: $currentProject->hasEnvFile() ? $currentProject->getEnvFile() : null,
+                    aliases: $this->projectService->getAliasesForPath($currentProject->path),
+                );
+            }
+
+            $response = new ProjectsListResponse(
+                projects: $projectInfos,
+                currentProject: $currentProjectResponse,
+                totalProjects: \count($projects),
+            );
+
+            return new CallToolResult([
+                new TextContent(text: \json_encode($response, JSON_PRETTY_PRINT)),
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Error listing projects', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return new CallToolResult([
+                new TextContent(text: 'Error: ' . $e->getMessage()),
+            ], isError: true);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two new MCP tools for project management that integrate with the existing project system.

## New Tools

### `projects-list`
- Lists all registered projects with their configuration details
- Shows current project, aliases, config files, and timestamps

### `project-switch` 
- Switches between projects using either paths or aliases
- Shows alias resolution details when applicable

### Configuration
- Added `project_operations` config section in `McpConfig`
- Added `MCP_PROJECT_OPERATIONS` environment variable support (defaults to `true`)
- Tools are conditionally registered based on configuration