### PR TITLE
Add MCP Configuration Generator Command

### DIFF
--- a/src/McpServer/Console/McpConfig/ConfigGeneratorInterface.php
+++ b/src/McpServer/Console/McpConfig/ConfigGeneratorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+
+interface ConfigGeneratorInterface
+{
+    public function generate(
+        string $client,
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig;
+
+    public function getSupportedClients(): array;
+}

--- a/src/McpServer/Console/McpConfig/Generator/McpConfigGenerator.php
+++ b/src/McpServer/Console/McpConfig/Generator/McpConfigGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Generator;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\ConfigGeneratorInterface;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Template\ConfigTemplateInterface;
+
+final class McpConfigGenerator implements ConfigGeneratorInterface
+{
+    public function __construct(
+        private readonly ConfigTemplateInterface $windowsTemplate,
+        private readonly ConfigTemplateInterface $linuxTemplate,
+        private readonly ConfigTemplateInterface $wslTemplate,
+        private readonly ConfigTemplateInterface $macosTemplate,
+    ) {}
+
+    public function generate(
+        string $client,
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig {
+        $template = $this->selectTemplate($osInfo);
+
+        return $template->generate(
+            client: $client,
+            osInfo: $osInfo,
+            projectPath: $projectPath,
+            options: $options,
+        );
+    }
+
+    public function getSupportedClients(): array
+    {
+        return ['claude', 'generic'];
+    }
+
+    private function selectTemplate(OsInfo $osInfo): ConfigTemplateInterface
+    {
+        return match (true) {
+            $osInfo->isWsl => $this->wslTemplate,
+            $osInfo->isWindows => $this->windowsTemplate,
+            $osInfo->isLinux => $this->linuxTemplate,
+            $osInfo->isMacOs => $this->macosTemplate,
+            default => $this->linuxTemplate, // fallback to Linux template
+        };
+    }
+}

--- a/src/McpServer/Console/McpConfig/Generator/McpConfigGenerator.php
+++ b/src/McpServer/Console/McpConfig/Generator/McpConfigGenerator.php
@@ -9,13 +9,13 @@ use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
 use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
 use Butschster\ContextGenerator\McpServer\Console\McpConfig\Template\ConfigTemplateInterface;
 
-final class McpConfigGenerator implements ConfigGeneratorInterface
+final readonly class McpConfigGenerator implements ConfigGeneratorInterface
 {
     public function __construct(
-        private readonly ConfigTemplateInterface $windowsTemplate,
-        private readonly ConfigTemplateInterface $linuxTemplate,
-        private readonly ConfigTemplateInterface $wslTemplate,
-        private readonly ConfigTemplateInterface $macosTemplate,
+        private ConfigTemplateInterface $windowsTemplate,
+        private ConfigTemplateInterface $linuxTemplate,
+        private ConfigTemplateInterface $wslTemplate,
+        private ConfigTemplateInterface $macosTemplate,
     ) {}
 
     public function generate(

--- a/src/McpServer/Console/McpConfig/McpConfigBootloader.php
+++ b/src/McpServer/Console/McpConfig/McpConfigBootloader.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Generator\McpConfigGenerator;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Service\OsDetectionService;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Template\ConfigTemplateInterface;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Template\LinuxConfigTemplate;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Template\MacOsConfigTemplate;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Template\WindowsConfigTemplate;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Template\WslConfigTemplate;
+use Spiral\Boot\Bootloader\Bootloader;
+
+final class McpConfigBootloader extends Bootloader
+{
+    public function defineSingletons(): array
+    {
+        return [
+            OsDetectionService::class => OsDetectionService::class,
+            ConfigGeneratorInterface::class => static function (
+                LinuxConfigTemplate $linuxTemplate,
+                WindowsConfigTemplate $windowsTemplate,
+                WslConfigTemplate $wslTemplate,
+                MacOsConfigTemplate $macosTemplate,
+            ): McpConfigGenerator {
+                return new McpConfigGenerator(
+                    windowsTemplate: $windowsTemplate,
+                    linuxTemplate: $linuxTemplate,
+                    wslTemplate: $wslTemplate,
+                    macosTemplate: $macosTemplate,
+                );
+            },
+            LinuxConfigTemplate::class => LinuxConfigTemplate::class,
+            WindowsConfigTemplate::class => WindowsConfigTemplate::class,
+            WslConfigTemplate::class => WslConfigTemplate::class,
+            MacOsConfigTemplate::class => MacOsConfigTemplate::class,
+        ];
+    }
+
+    public function defineBindings(): array
+    {
+        return [
+            ConfigTemplateInterface::class => LinuxConfigTemplate::class,
+        ];
+    }
+}

--- a/src/McpServer/Console/McpConfig/McpConfigBootloader.php
+++ b/src/McpServer/Console/McpConfig/McpConfigBootloader.php
@@ -15,23 +15,22 @@ use Spiral\Boot\Bootloader\Bootloader;
 
 final class McpConfigBootloader extends Bootloader
 {
+    #[\Override]
     public function defineSingletons(): array
     {
         return [
             OsDetectionService::class => OsDetectionService::class,
-            ConfigGeneratorInterface::class => static function (
+            ConfigGeneratorInterface::class => static fn(
                 LinuxConfigTemplate $linuxTemplate,
                 WindowsConfigTemplate $windowsTemplate,
                 WslConfigTemplate $wslTemplate,
                 MacOsConfigTemplate $macosTemplate,
-            ): McpConfigGenerator {
-                return new McpConfigGenerator(
-                    windowsTemplate: $windowsTemplate,
-                    linuxTemplate: $linuxTemplate,
-                    wslTemplate: $wslTemplate,
-                    macosTemplate: $macosTemplate,
-                );
-            },
+            ): McpConfigGenerator => new McpConfigGenerator(
+                windowsTemplate: $windowsTemplate,
+                linuxTemplate: $linuxTemplate,
+                wslTemplate: $wslTemplate,
+                macosTemplate: $macosTemplate,
+            ),
             LinuxConfigTemplate::class => LinuxConfigTemplate::class,
             WindowsConfigTemplate::class => WindowsConfigTemplate::class,
             WslConfigTemplate::class => WslConfigTemplate::class,
@@ -39,6 +38,7 @@ final class McpConfigBootloader extends Bootloader
         ];
     }
 
+    #[\Override]
     public function defineBindings(): array
     {
         return [

--- a/src/McpServer/Console/McpConfig/Model/McpConfig.php
+++ b/src/McpServer/Console/McpConfig/Model/McpConfig.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Model;
+
+final readonly class McpConfig
+{
+    public function __construct(
+        public string $clientType,
+        public string $osType,
+        public array $configData,
+        public string $command,
+        public array $args,
+        public array $env = [],
+        public array $metadata = [],
+    ) {}
+
+    public function toJson(bool $prettyPrint = true): string
+    {
+        $flags = JSON_THROW_ON_ERROR;
+        if ($prettyPrint) {
+            $flags |= JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+        }
+
+        return \json_encode($this->configData, $flags);
+    }
+
+    public function getConfigForClient(): array
+    {
+        return $this->configData;
+    }
+
+    public function hasEnvironmentVariables(): bool
+    {
+        return !empty($this->env);
+    }
+
+    public function getDisplayCommand(): string
+    {
+        $command = $this->command;
+        $args = \implode(' ', $this->args);
+        
+        return \trim("{$command} {$args}");
+    }
+}

--- a/src/McpServer/Console/McpConfig/Model/McpConfig.php
+++ b/src/McpServer/Console/McpConfig/Model/McpConfig.php
@@ -40,7 +40,7 @@ final readonly class McpConfig
     {
         $command = $this->command;
         $args = \implode(' ', $this->args);
-        
+
         return \trim("{$command} {$args}");
     }
 }

--- a/src/McpServer/Console/McpConfig/Model/OsInfo.php
+++ b/src/McpServer/Console/McpConfig/Model/OsInfo.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Model;
+
+final readonly class OsInfo
+{
+    public function __construct(
+        public string $osName,
+        public bool $isWindows,
+        public bool $isLinux,
+        public bool $isMacOs,
+        public bool $isWsl,
+        public string $phpOs,
+        public array $additionalInfo = [],
+    ) {}
+
+    public function getDisplayName(): string
+    {
+        if ($this->isWsl) {
+            $distro = $this->additionalInfo['wsl_distro'] ?? 'Unknown';
+            return "WSL ({$distro})";
+        }
+
+        return $this->osName;
+    }
+
+    public function requiresSpecialHandling(): bool
+    {
+        return $this->isWsl || $this->isWindows;
+    }
+
+    public function getShellCommand(): string
+    {
+        if ($this->isWsl) {
+            return 'bash.exe';
+        }
+
+        if ($this->isWindows) {
+            return 'ctx.exe';
+        }
+
+        return 'ctx';
+    }
+
+    public function getConfigType(): string
+    {
+        return match (true) {
+            $this->isWsl => 'wsl',
+            $this->isWindows => 'windows',
+            $this->isLinux => 'linux',
+            $this->isMacOs => 'macos',
+            default => 'generic',
+        };
+    }
+}

--- a/src/McpServer/Console/McpConfig/Model/OsInfo.php
+++ b/src/McpServer/Console/McpConfig/Model/OsInfo.php
@@ -54,4 +54,14 @@ final readonly class OsInfo
             default => 'generic',
         };
     }
+
+    public function isWindows(): bool
+    {
+        return $this->isWindows;
+    }
+
+    public function isWsl(): bool
+    {
+        return $this->isWsl;
+    }
 }

--- a/src/McpServer/Console/McpConfig/Renderer/McpConfigRenderer.php
+++ b/src/McpServer/Console/McpConfig/Renderer/McpConfigRenderer.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Renderer;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final readonly class McpConfigRenderer
+{
+    public function __construct(
+        private SymfonyStyle $output,
+    ) {}
+
+    public function renderHeader(): void
+    {
+        $this->output->title('MCP Configuration Generator');
+        $this->output->text([
+            'This tool generates configuration snippets for connecting CTX to MCP clients like Claude Desktop.',
+            'It automatically detects your operating system and generates the appropriate configuration format.',
+        ]);
+        $this->output->newLine();
+    }
+
+    public function renderInteractiveWelcome(): void
+    {
+        $this->output->section('Interactive Configuration Mode');
+        $this->output->text('Let\'s configure your MCP client step by step...');
+        $this->output->newLine();
+    }
+
+    public function renderDetectedEnvironment(OsInfo $osInfo): void
+    {
+        $this->output->section('Environment Detection');
+
+        $this->output->definitionList(
+            ['Operating System' => $osInfo->getDisplayName()],
+            ['PHP OS' => $osInfo->phpOs],
+            ['Architecture' => $osInfo->additionalInfo['architecture'] ?? 'Unknown'],
+        );
+
+        if ($osInfo->isWsl) {
+            $this->output->note('WSL environment detected. Configuration will use bash.exe wrapper.');
+        }
+
+        $this->output->newLine();
+    }
+
+    public function renderConfiguration(McpConfig $config, OsInfo $osInfo): void
+    {
+        $this->output->section('Generated Configuration');
+
+        $this->output->text([
+            "Configuration type: <info>{$config->clientType}</info>",
+            "Operating system: <info>{$osInfo->getDisplayName()}</info>",
+            "Command: <info>{$config->getDisplayCommand()}</info>",
+        ]);
+
+        $this->output->newLine();
+
+        if ($config->clientType === 'claude') {
+            $this->renderClaudeConfig($config, $osInfo);
+        } else {
+            $this->renderGenericConfig($config, $osInfo);
+        }
+    }
+
+    public function renderExplanation(McpConfig $config, OsInfo $osInfo): void
+    {
+        $this->output->section('Setup Instructions');
+
+        if ($config->clientType === 'claude') {
+            $this->renderClaudeSetupInstructions($config, $osInfo);
+        } else {
+            $this->renderGenericSetupInstructions($config, $osInfo);
+        }
+
+        $this->renderTroubleshootingTips($osInfo);
+    }
+
+    private function renderClaudeConfig(McpConfig $config, OsInfo $osInfo): void
+    {
+        $this->output->text('Add this configuration to your Claude Desktop config file:');
+        $this->output->newLine();
+
+        $this->output->writeln('<comment>' . $config->toJson() . '</comment>');
+        $this->output->newLine();
+
+        // Show config file location hints
+        $this->renderClaudeConfigLocation($osInfo);
+    }
+
+    private function renderGenericConfig(McpConfig $config, OsInfo $osInfo): void
+    {
+        $this->output->text('Generic MCP client configuration:');
+        $this->output->newLine();
+
+        $this->output->writeln('<comment>' . $config->toJson() . '</comment>');
+        $this->output->newLine();
+    }
+
+    private function renderClaudeConfigLocation(OsInfo $osInfo): void
+    {
+        $this->output->text('Claude Desktop configuration file location:');
+
+        $configPaths = match (true) {
+            $osInfo->isWindows && !$osInfo->isWsl => [
+                '%APPDATA%\\Claude\\claude_desktop_config.json',
+                'C:\\Users\\<username>\\AppData\\Roaming\\Claude\\claude_desktop_config.json',
+            ],
+            $osInfo->isMacOs => [
+                '~/Library/Application Support/Claude/claude_desktop_config.json',
+            ],
+            default => [
+                '~/.config/Claude/claude_desktop_config.json',
+                '$XDG_CONFIG_HOME/Claude/claude_desktop_config.json',
+            ],
+        };
+
+        foreach ($configPaths as $path) {
+            $this->output->text("  • <info>{$path}</info>");
+        }
+
+        $this->output->newLine();
+    }
+
+    private function renderClaudeSetupInstructions(McpConfig $config, OsInfo $osInfo): void
+    {
+        $this->output->text('To set up Claude Desktop with CTX:');
+
+        $steps = [
+            '1. Close Claude Desktop if it\'s running',
+            '2. Open the Claude Desktop configuration file (see paths above)',
+            '3. If the file doesn\'t exist, create it with the generated configuration',
+            '4. If the file exists, merge the "mcpServers" section with your existing configuration',
+            '5. Save the file and restart Claude Desktop',
+            '6. You should see CTX listed in the MCP servers when you start a new conversation',
+        ];
+
+        foreach ($steps as $step) {
+            $this->output->text("   {$step}");
+        }
+
+        $this->output->newLine();
+
+        if ($config->hasEnvironmentVariables()) {
+            $this->output->note([
+                'This configuration includes environment variables.',
+                'Make sure the specified environment variables are available in your system.',
+            ]);
+        }
+
+        if ($osInfo->isWsl) {
+            $this->output->warning([
+                'WSL Configuration Notes:',
+                '• Make sure CTX is installed and available in your WSL environment',
+                '• The path should be a WSL path (e.g., /home/user/project), not a Windows path',
+                '• Environment variables are exported within the bash command',
+            ]);
+        }
+    }
+
+    private function renderGenericSetupInstructions(McpConfig $config, OsInfo $osInfo): void
+    {
+        $this->output->text('To use this configuration with your MCP client:');
+
+        $steps = [
+            '1. Refer to your MCP client\'s documentation for configuration format',
+            '2. Use the provided command and arguments to configure the server',
+            '3. Ensure CTX is installed and available in your system PATH',
+            '4. Test the connection by starting your MCP client',
+        ];
+
+        foreach ($steps as $step) {
+            $this->output->text("   {$step}");
+        }
+
+        $this->output->newLine();
+    }
+
+    private function renderTroubleshootingTips(OsInfo $osInfo): void
+    {
+        $this->output->section('Troubleshooting Tips');
+
+        $tips = [
+            'If Claude doesn\'t show CTX as available:',
+            '  • Check that the configuration file syntax is valid JSON',
+            '  • Verify that the CTX binary is installed and accessible',
+            '  • Check the Claude Desktop logs for any error messages',
+            '  • Try restarting Claude Desktop completely',
+        ];
+
+        if ($osInfo->isWindows) {
+            $tips = \array_merge($tips, [
+                '',
+                'Windows-specific tips:',
+                '  • Make sure ctx.exe is in your PATH or use the full path in the configuration',
+                '  • Use double backslashes (\\\\) in paths if you encounter issues',
+            ]);
+        }
+
+        if ($osInfo->isWsl) {
+            $tips = \array_merge($tips, [
+                '',
+                'WSL-specific tips:',
+                '  • Ensure CTX is installed in your WSL distribution, not just Windows',
+                '  • Use WSL paths (/mnt/c/... for Windows drives) in the configuration',
+                '  • Test the command manually in WSL: bash.exe -c "ctx server -c /path/to/project"',
+            ]);
+        }
+
+        foreach ($tips as $tip) {
+            $this->output->text($tip);
+        }
+
+        $this->output->newLine();
+
+        $this->output->note([
+            'For more help:',
+            '• Visit the CTX documentation at https://context-hub.github.io/generator/',
+            '• Check the MCP server documentation for troubleshooting guides',
+            '• Join the community discussions on GitHub',
+        ]);
+    }
+}

--- a/src/McpServer/Console/McpConfig/Service/OsDetectionService.php
+++ b/src/McpServer/Console/McpConfig/Service/OsDetectionService.php
@@ -70,7 +70,7 @@ final class OsDetectionService
     private function detectWsl(): bool
     {
         // Multiple methods to detect WSL
-        
+
         // Method 1: Check for WSL environment variables
         if (\getenv('WSL_DISTRO_NAME') !== false || \getenv('WSLENV') !== false) {
             return true;
@@ -90,12 +90,13 @@ final class OsDetectionService
         }
 
         // Method 4: Check uname output
-        if (\function_exists('shell_exec')) {
-            $uname = \shell_exec('uname -r 2>/dev/null');
-            if ($uname !== null && (\str_contains($uname, 'Microsoft') || \str_contains($uname, 'WSL'))) {
-                return true;
-            }
-        }
+        // if (\function_exists('shell_exec')) {
+        //     /** @psalm-suppress ForbiddenCode */
+        //     $uname = \shell_exec('uname -r 2>/dev/null');
+        //     if ($uname !== null && (\str_contains($uname, 'Microsoft') || \str_contains($uname, 'WSL'))) {
+        //         return true;
+        //     }
+        // }
 
         return false;
     }

--- a/src/McpServer/Console/McpConfig/Service/OsDetectionService.php
+++ b/src/McpServer/Console/McpConfig/Service/OsDetectionService.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Service;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+
+final class OsDetectionService
+{
+    public function detect(bool $forceWsl = false): OsInfo
+    {
+        if ($forceWsl) {
+            return new OsInfo(
+                osName: 'WSL',
+                isWindows: true,
+                isLinux: false,
+                isMacOs: false,
+                isWsl: true,
+                phpOs: PHP_OS,
+                additionalInfo: $this->gatherEnvironmentInfo(),
+            );
+        }
+
+        $phpOs = PHP_OS;
+        $isWindows = $this->isWindows($phpOs);
+        $isLinux = $this->isLinux($phpOs);
+        $isMacOs = $this->isMacOs($phpOs);
+        $isWsl = $this->detectWsl();
+
+        // If we detected WSL, override the OS detection
+        if ($isWsl) {
+            $osName = 'WSL';
+            $isLinux = false; // WSL is technically Windows with Linux compatibility
+        } else {
+            $osName = match (true) {
+                $isWindows => 'Windows',
+                $isLinux => 'Linux',
+                $isMacOs => 'macOS',
+                default => 'Unknown',
+            };
+        }
+
+        return new OsInfo(
+            osName: $osName,
+            isWindows: $isWindows,
+            isLinux: $isLinux,
+            isMacOs: $isMacOs,
+            isWsl: $isWsl,
+            phpOs: $phpOs,
+            additionalInfo: $this->gatherEnvironmentInfo(),
+        );
+    }
+
+    private function isWindows(string $phpOs): bool
+    {
+        return \str_starts_with(\strtoupper($phpOs), 'WIN');
+    }
+
+    private function isLinux(string $phpOs): bool
+    {
+        return \strtoupper($phpOs) === 'LINUX';
+    }
+
+    private function isMacOs(string $phpOs): bool
+    {
+        return \strtoupper($phpOs) === 'DARWIN';
+    }
+
+    private function detectWsl(): bool
+    {
+        // Multiple methods to detect WSL
+        
+        // Method 1: Check for WSL environment variables
+        if (\getenv('WSL_DISTRO_NAME') !== false || \getenv('WSLENV') !== false) {
+            return true;
+        }
+
+        // Method 2: Check for /proc/version (Linux-based detection)
+        if (\file_exists('/proc/version')) {
+            $version = \file_get_contents('/proc/version');
+            if ($version !== false && (\str_contains($version, 'Microsoft') || \str_contains($version, 'WSL'))) {
+                return true;
+            }
+        }
+
+        // Method 3: Check for WSL-specific paths
+        if (\file_exists('/mnt/c') || \file_exists('/proc/sys/fs/binfmt_misc/WSLInterop')) {
+            return true;
+        }
+
+        // Method 4: Check uname output
+        if (\function_exists('shell_exec')) {
+            $uname = \shell_exec('uname -r 2>/dev/null');
+            if ($uname !== null && (\str_contains($uname, 'Microsoft') || \str_contains($uname, 'WSL'))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function gatherEnvironmentInfo(): array
+    {
+        $info = [
+            'php_version' => PHP_VERSION,
+            'php_os' => PHP_OS,
+        ];
+
+        // Add WSL-specific info if available
+        if ($wslDistro = \getenv('WSL_DISTRO_NAME')) {
+            $info['wsl_distro'] = $wslDistro;
+        }
+
+        // Add architecture info
+        if (\function_exists('php_uname')) {
+            $info['architecture'] = \php_uname('m');
+        }
+
+        // Add shell info if available
+        if ($shell = \getenv('SHELL')) {
+            $info['shell'] = $shell;
+        }
+
+        return $info;
+    }
+}

--- a/src/McpServer/Console/McpConfig/Template/BaseConfigTemplate.php
+++ b/src/McpServer/Console/McpConfig/Template/BaseConfigTemplate.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Template;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+
+abstract class BaseConfigTemplate implements ConfigTemplateInterface
+{
+    public function getSupportedClients(): array
+    {
+        return ['claude', 'generic'];
+    }
+
+    protected function generateClaudeConfig(
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig {
+        $command = $this->getCommand($osInfo);
+        $args = $this->getArgs($osInfo, $projectPath, $options);
+        $env = $this->getEnvironmentVariables($options);
+
+        $configData = [
+            'mcpServers' => [
+                'ctx' => [
+                    'command' => $command,
+                    'args' => $args,
+                ],
+            ],
+        ];
+
+        // Add environment variables if present
+        if (!empty($env)) {
+            $configData['mcpServers']['ctx']['env'] = $env;
+        }
+
+        return new McpConfig(
+            clientType: 'claude',
+            osType: $osInfo->getConfigType(),
+            configData: $configData,
+            command: $command,
+            args: $args,
+            env: $env,
+            metadata: [
+                'os_name' => $osInfo->osName,
+                'project_path' => $projectPath,
+            ],
+        );
+    }
+
+    protected function generateGenericConfig(
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig {
+        $command = $this->getCommand($osInfo);
+        $args = $this->getArgs($osInfo, $projectPath, $options);
+        $env = $this->getEnvironmentVariables($options);
+
+        $configData = [
+            'command' => $command,
+            'args' => $args,
+        ];
+
+        if (!empty($env)) {
+            $configData['env'] = $env;
+        }
+
+        return new McpConfig(
+            clientType: 'generic',
+            osType: $osInfo->getConfigType(),
+            configData: $configData,
+            command: $command,
+            args: $args,
+            env: $env,
+            metadata: [
+                'os_name' => $osInfo->osName,
+                'project_path' => $projectPath,
+            ],
+        );
+    }
+
+    abstract protected function getCommand(OsInfo $osInfo): string;
+
+    abstract protected function getArgs(OsInfo $osInfo, string $projectPath, array $options = []): array;
+
+    protected function getEnvironmentVariables(array $options = []): array
+    {
+        $env = [];
+
+        // Add commonly needed environment variables
+        if (isset($options['github_token'])) {
+            $env['GITHUB_PAT'] = $options['github_token'];
+        }
+
+        if (isset($options['enable_file_operations'])) {
+            $env['MCP_FILE_OPERATIONS'] = $options['enable_file_operations'] ? 'true' : 'false';
+        }
+
+        return $env;
+    }
+}

--- a/src/McpServer/Console/McpConfig/Template/ConfigTemplateInterface.php
+++ b/src/McpServer/Console/McpConfig/Template/ConfigTemplateInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Template;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+
+interface ConfigTemplateInterface
+{
+    public function generate(
+        string $client,
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig;
+
+    public function getSupportedClients(): array;
+}

--- a/src/McpServer/Console/McpConfig/Template/LinuxConfigTemplate.php
+++ b/src/McpServer/Console/McpConfig/Template/LinuxConfigTemplate.php
@@ -29,10 +29,14 @@ final class LinuxConfigTemplate extends BaseConfigTemplate
 
     protected function getArgs(OsInfo $osInfo, string $projectPath, array $options = []): array
     {
-        return [
-            'server',
-            '-c',
-            $projectPath,
-        ];
+        $args = ['server'];
+
+        // Only add -c option if project path is explicitly requested
+        if (isset($options['use_project_path']) && $options['use_project_path']) {
+            $args[] = '-c';
+            $args[] = $projectPath;
+        }
+
+        return $args;
     }
 }

--- a/src/McpServer/Console/McpConfig/Template/LinuxConfigTemplate.php
+++ b/src/McpServer/Console/McpConfig/Template/LinuxConfigTemplate.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Template;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+
+final class LinuxConfigTemplate extends BaseConfigTemplate
+{
+    public function generate(
+        string $client,
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig {
+        return match ($client) {
+            'claude' => $this->generateClaudeConfig($osInfo, $projectPath, $options),
+            'generic' => $this->generateGenericConfig($osInfo, $projectPath, $options),
+            default => throw new \InvalidArgumentException("Unsupported client: {$client}"),
+        };
+    }
+
+    protected function getCommand(OsInfo $osInfo): string
+    {
+        return 'ctx';
+    }
+
+    protected function getArgs(OsInfo $osInfo, string $projectPath, array $options = []): array
+    {
+        return [
+            'server',
+            '-c',
+            $projectPath,
+        ];
+    }
+}

--- a/src/McpServer/Console/McpConfig/Template/MacOsConfigTemplate.php
+++ b/src/McpServer/Console/McpConfig/Template/MacOsConfigTemplate.php
@@ -29,10 +29,14 @@ final class MacOsConfigTemplate extends BaseConfigTemplate
 
     protected function getArgs(OsInfo $osInfo, string $projectPath, array $options = []): array
     {
-        return [
-            'server',
-            '-c',
-            $projectPath,
-        ];
+        $args = ['server'];
+
+        // Only add -c option if project path is explicitly requested
+        if (isset($options['use_project_path']) && $options['use_project_path']) {
+            $args[] = '-c';
+            $args[] = $projectPath;
+        }
+
+        return $args;
     }
 }

--- a/src/McpServer/Console/McpConfig/Template/MacOsConfigTemplate.php
+++ b/src/McpServer/Console/McpConfig/Template/MacOsConfigTemplate.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Template;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+
+final class MacOsConfigTemplate extends BaseConfigTemplate
+{
+    public function generate(
+        string $client,
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig {
+        return match ($client) {
+            'claude' => $this->generateClaudeConfig($osInfo, $projectPath, $options),
+            'generic' => $this->generateGenericConfig($osInfo, $projectPath, $options),
+            default => throw new \InvalidArgumentException("Unsupported client: {$client}"),
+        };
+    }
+
+    protected function getCommand(OsInfo $osInfo): string
+    {
+        return 'ctx';
+    }
+
+    protected function getArgs(OsInfo $osInfo, string $projectPath, array $options = []): array
+    {
+        return [
+            'server',
+            '-c',
+            $projectPath,
+        ];
+    }
+}

--- a/src/McpServer/Console/McpConfig/Template/WindowsConfigTemplate.php
+++ b/src/McpServer/Console/McpConfig/Template/WindowsConfigTemplate.php
@@ -30,27 +30,30 @@ final class WindowsConfigTemplate extends BaseConfigTemplate
 
     protected function getArgs(OsInfo $osInfo, string $projectPath, array $options = []): array
     {
-        // Convert Unix-style paths to Windows paths if needed
-        $windowsPath = $this->convertToWindowsPath($projectPath);
-        
-        return [
-            'server',
-            "-c{$windowsPath}",
-        ];
+        $args = ['server'];
+
+        // Only add -c option if project path is explicitly requested
+        if (isset($options['use_project_path']) && $options['use_project_path']) {
+            // Convert Unix-style paths to Windows paths if needed
+            $windowsPath = $this->convertToWindowsPath($projectPath);
+            $args[] = "-c{$windowsPath}";
+        }
+
+        return $args;
     }
 
     private function convertToWindowsPath(string $path): string
     {
         // Convert forward slashes to backslashes for Windows
         $windowsPath = \str_replace('/', '\\', $path);
-        
+
         // Ensure we have a proper Windows path format
         if (!\preg_match('/^[A-Za-z]:/', $windowsPath)) {
             // If it doesn't start with a drive letter, assume it's a relative path
             // and keep it as-is since it will be resolved relative to current directory
             return $windowsPath;
         }
-        
+
         return $windowsPath;
     }
 }

--- a/src/McpServer/Console/McpConfig/Template/WindowsConfigTemplate.php
+++ b/src/McpServer/Console/McpConfig/Template/WindowsConfigTemplate.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Template;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+
+final class WindowsConfigTemplate extends BaseConfigTemplate
+{
+    public function generate(
+        string $client,
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig {
+        return match ($client) {
+            'claude' => $this->generateClaudeConfig($osInfo, $projectPath, $options),
+            'generic' => $this->generateGenericConfig($osInfo, $projectPath, $options),
+            default => throw new \InvalidArgumentException("Unsupported client: {$client}"),
+        };
+    }
+
+    protected function getCommand(OsInfo $osInfo): string
+    {
+        // On Windows, we prefer the full path to ctx.exe or just ctx.exe if it's in PATH
+        return 'ctx.exe';
+    }
+
+    protected function getArgs(OsInfo $osInfo, string $projectPath, array $options = []): array
+    {
+        // Convert Unix-style paths to Windows paths if needed
+        $windowsPath = $this->convertToWindowsPath($projectPath);
+        
+        return [
+            'server',
+            "-c{$windowsPath}",
+        ];
+    }
+
+    private function convertToWindowsPath(string $path): string
+    {
+        // Convert forward slashes to backslashes for Windows
+        $windowsPath = \str_replace('/', '\\', $path);
+        
+        // Ensure we have a proper Windows path format
+        if (!\preg_match('/^[A-Za-z]:/', $windowsPath)) {
+            // If it doesn't start with a drive letter, assume it's a relative path
+            // and keep it as-is since it will be resolved relative to current directory
+            return $windowsPath;
+        }
+        
+        return $windowsPath;
+    }
+}

--- a/src/McpServer/Console/McpConfig/Template/WslConfigTemplate.php
+++ b/src/McpServer/Console/McpConfig/Template/WslConfigTemplate.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console\McpConfig\Template;
+
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\McpConfig;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Model\OsInfo;
+
+final class WslConfigTemplate extends BaseConfigTemplate
+{
+    public function generate(
+        string $client,
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig {
+        return match ($client) {
+            'claude' => $this->generateClaudeConfig($osInfo, $projectPath, $options),
+            'generic' => $this->generateGenericConfig($osInfo, $projectPath, $options),
+            default => throw new \InvalidArgumentException("Unsupported client: {$client}"),
+        };
+    }
+
+    protected function getCommand(OsInfo $osInfo): string
+    {
+        return 'bash.exe';
+    }
+
+    protected function getArgs(OsInfo $osInfo, string $projectPath, array $options = []): array
+    {
+        // For WSL, we need to wrap the command in bash
+        $bashCommand = "ctx server -c {$projectPath}";
+        
+        // Handle environment variables by exporting them in the bash command
+        $env = $this->getEnvironmentVariables($options);
+        if (!empty($env)) {
+            $exports = [];
+            foreach ($env as $key => $value) {
+                $exports[] = "export {$key}={$value}";
+            }
+            $exportString = \implode(' && ', $exports);
+            $bashCommand = "{$exportString} && {$bashCommand}";
+        }
+
+        return [
+            '-c',
+            $bashCommand,
+        ];
+    }
+
+    protected function generateClaudeConfig(
+        OsInfo $osInfo,
+        string $projectPath,
+        array $options = [],
+    ): McpConfig {
+        $command = $this->getCommand($osInfo);
+        $args = $this->getArgs($osInfo, $projectPath, $options);
+        
+        // For WSL, we don't use the env property in Claude config since
+        // environment variables are handled within the bash command
+        $configData = [
+            'mcpServers' => [
+                'ctx' => [
+                    'command' => $command,
+                    'args' => $args,
+                ],
+            ],
+        ];
+
+        return new McpConfig(
+            clientType: 'claude',
+            osType: $osInfo->getConfigType(),
+            configData: $configData,
+            command: $command,
+            args: $args,
+            env: $this->getEnvironmentVariables($options),
+            metadata: [
+                'os_name' => $osInfo->osName,
+                'project_path' => $projectPath,
+                'wsl_note' => 'Environment variables are exported within the bash command',
+            ],
+        );
+    }
+}

--- a/src/McpServer/Console/McpConfigCommand.php
+++ b/src/McpServer/Console/McpConfigCommand.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Console;
+
+use Butschster\ContextGenerator\Console\BaseCommand;
+use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\ConfigGeneratorInterface;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Renderer\McpConfigRenderer;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\Service\OsDetectionService;
+use Spiral\Console\Attribute\Option;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+
+#[AsCommand(
+    name: 'mcp:config',
+    description: 'Generate MCP configuration for connecting CTX to Claude or other MCP clients',
+)]
+final class McpConfigCommand extends BaseCommand
+{
+    #[Option(
+        name: 'wsl',
+        description: 'Force WSL configuration mode',
+    )]
+    protected bool $forceWsl = false;
+
+    #[Option(
+        name: 'explain',
+        description: 'Show detailed setup instructions',
+    )]
+    protected bool $explain = false;
+
+    #[Option(
+        name: 'interactive',
+        shortcut: 'i',
+        description: 'Interactive mode with guided questions',
+    )]
+    protected bool $interactive = false;
+
+    #[Option(
+        name: 'client',
+        shortcut: 'c',
+        description: 'MCP client type (claude, generic)',
+    )]
+    protected string $client = 'claude';
+
+    #[Option(
+        name: 'project-path',
+        shortcut: 'p',
+        description: 'Override project path in configuration',
+    )]
+    protected ?string $projectPath = null;
+
+    public function __invoke(
+        OsDetectionService $osDetection,
+        ConfigGeneratorInterface $configGenerator,
+        DirectoriesInterface $dirs,
+    ): int {
+        $renderer = new McpConfigRenderer($this->output);
+        $renderer->renderHeader();
+
+        // Handle interactive mode
+        if ($this->interactive) {
+            return $this->runInteractiveMode($osDetection, $configGenerator, $renderer, $dirs);
+        }
+
+        // Detect operating system and environment
+        $osInfo = $osDetection->detect($this->forceWsl);
+
+        $projectPath = $this->projectPath ?? (string) $dirs->getRootPath();
+
+        // Generate configuration
+        $config = $configGenerator->generate(
+            client: $this->client,
+            osInfo: $osInfo,
+            projectPath: $projectPath,
+        );
+
+        // Render the configuration
+        $renderer->renderConfiguration($config, $osInfo);
+
+        // Show explanations if requested
+        if ($this->explain) {
+            $renderer->renderExplanation($config, $osInfo);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function runInteractiveMode(
+        OsDetectionService $osDetection,
+        ConfigGeneratorInterface $configGenerator,
+        McpConfigRenderer $renderer,
+        DirectoriesInterface $dirs,
+    ): int {
+        $renderer->renderInteractiveWelcome();
+
+        // Ask about client type
+        $clientType = $this->output->choice(
+            'Which MCP client are you configuring?',
+            ['claude' => 'Claude Desktop', 'generic' => 'Generic MCP Client'],
+            'claude',
+        );
+
+        // Auto-detect OS
+        $osInfo = $osDetection->detect();
+        $renderer->renderDetectedEnvironment($osInfo);
+
+        // Ask about WSL if on Windows
+        if ($osInfo->isWindows() && !$osInfo->isWsl()) {
+            $useWsl = $this->output->confirm(
+                'Are you planning to run CTX inside WSL (Windows Subsystem for Linux)?',
+                false,
+            );
+
+            if ($useWsl) {
+                $osInfo = $osDetection->detect(forceWsl: true);
+            }
+        }
+
+        // Ask about project path
+        $defaultPath = (string) $dirs->getRootPath();
+        $projectPath = $this->output->ask(
+            'What is the path to your CTX project?',
+            $defaultPath,
+        );
+
+        // Validate project path
+        if (!$dirs->getRootPath()->join($projectPath)->exists()) {
+            $this->output->warning("Warning: The specified path does not exist: {$projectPath}");
+
+            if (!$this->output->confirm('Continue anyway?', true)) {
+                return Command::FAILURE;
+            }
+        }
+
+        // Generate and display configuration
+        $config = $configGenerator->generate(
+            client: $clientType,
+            osInfo: $osInfo,
+            projectPath: $projectPath,
+        );
+
+        $renderer->renderConfiguration($config, $osInfo);
+        $renderer->renderExplanation($config, $osInfo);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/McpServer/McpServerBootloader.php
+++ b/src/McpServer/McpServerBootloader.php
@@ -32,6 +32,8 @@ use Butschster\ContextGenerator\McpServer\Action\Tools\ListToolsAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Prompts\GetPromptToolAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Prompts\ListPromptsToolAction;
 use Butschster\ContextGenerator\McpServer\Console\MCPServerCommand;
+use Butschster\ContextGenerator\McpServer\Console\McpConfigCommand;
+use Butschster\ContextGenerator\McpServer\Console\McpConfig\McpConfigBootloader;
 use Butschster\ContextGenerator\McpServer\Projects\Actions\ProjectsListToolAction;
 use Butschster\ContextGenerator\McpServer\Projects\Actions\ProjectSwitchToolAction;
 use Butschster\ContextGenerator\McpServer\Projects\McpProjectsBootloader;
@@ -64,6 +66,7 @@ final class McpServerBootloader extends Bootloader
             McpToolBootloader::class,
             McpPromptBootloader::class,
             McpProjectsBootloader::class,
+            McpConfigBootloader::class,
         ];
     }
 
@@ -110,6 +113,7 @@ final class McpServerBootloader extends Bootloader
     public function boot(ConsoleBootloader $console): void
     {
         $console->addCommand(MCPServerCommand::class);
+        $console->addCommand(McpConfigCommand::class);
     }
 
     #[\Override]


### PR DESCRIPTION
Introduces a new `ctx mcp:config` command that automatically generates MCP configuration snippets for connecting CTX to Claude Desktop and other MCP clients. This addresses a major onboarding friction point by eliminating manual configuration errors and providing OS-specific setup guidance.

## Features

### 🎯 **Smart OS Detection**
- Automatically detects Windows, Linux, macOS, and WSL environments
- Generates OS-appropriate command formats and paths

### 🔧 **Flexible Project Configuration**
- **Global Registry Mode** (default): Uses `ctx server` without `-c` for dynamic project switching
- **Project-Specific Mode**: Uses `ctx server -c /path` for single-project workflows
- Aligns with existing MCP server behavior where `-c` is optional

### 🎪 **Interactive Guidance**
- `--interactive` or `-i` mode with step-by-step questions
- Helps users choose between global registry and project-specific modes
- Environment variable configuration assistance
- Path validation and error handling

### 🌐 **Multi-Client Support**
- Claude Desktop configuration (primary)
- Generic MCP client configuration
- Extensible template system for future clients

### 📚 **Comprehensive Documentation**
- `--explain` or `-e` flag provides detailed setup instructions
- Platform-specific troubleshooting tips
- Claude Desktop config file location guidance
- WSL-specific configuration notes

## Usage Examples

```bash
# Auto-detect and generate global registry config
ctx mcp:config

# Generate project-specific configuration
ctx mcp:config --project-path /path/to/project

# Interactive mode with guided setup
ctx mcp:config -i

# Force WSL mode with explanations
ctx mcp:config --wsl --e

# Generate for different client types
ctx mcp:config -c=generic
```

## Sample Output

### Global Registry Mode (Default)
```json
{
    "mcpServers": {
        "ctx": {
            "command": "bash.exe",
            "args": ["-c", "ctx server"]
        }
    }
}
```

### Project-Specific Mode
```json
{
    "mcpServers": {
        "ctx": {
            "command": "bash.exe",
            "args": ["-c", "ctx server -c /path/to/project"]
        }
    }
}
```