### PR TITLE
feat: Add file statistics to generated markdown files

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -11,6 +11,7 @@ use Butschster\ContextGenerator\Config\Registry\ConfigRegistryAccessor;
 use Butschster\ContextGenerator\Console\Renderer\GenerateCommandRenderer;
 use Butschster\ContextGenerator\DirectoriesInterface;
 use Butschster\ContextGenerator\Document\Compiler\DocumentCompiler;
+use Spiral\Files\FilesInterface;
 use Spiral\Console\Attribute\Option;
 use Spiral\Core\Container;
 use Spiral\Core\Scope;
@@ -88,6 +89,7 @@ final class GenerateCommand extends BaseCommand
                     DocumentCompiler $compiler,
                     ConfigurationProvider $configProvider,
                     DirectoriesInterface $dirs,
+                    FilesInterface $files,
                 ): int {
                     try {
                         // Get the appropriate loader based on options provided
@@ -120,7 +122,11 @@ final class GenerateCommand extends BaseCommand
                     }
 
                     // Create the renderer for consistent output formatting
-                    $renderer = new GenerateCommandRenderer($this->output);
+                    $renderer = new GenerateCommandRenderer(
+                        output: $this->output,
+                        files: $files,
+                        basePath: $dirs->getOutputPath()->toString(),
+                    );
 
                     // Display summary header
                     $this->output->writeln('');

--- a/src/Console/Renderer/GenerateCommandRenderer.php
+++ b/src/Console/Renderer/GenerateCommandRenderer.php
@@ -161,7 +161,7 @@ final readonly class GenerateCommandRenderer
                 '<fg=yellow>%s Warning:</> Could not read file statistics for %s: %s',
                 self::WARNING_SYMBOL,
                 $outputPath,
-                $e->getMessage()
+                $e->getMessage(),
             ));
             return null;
         }
@@ -176,14 +176,14 @@ final readonly class GenerateCommandRenderer
         $i = 0;
 
         while ($bytes >= 1024 && $i < \count($units) - 1) {
-            $bytes = (float) $bytes / 1024;
+            $bytes = (float) $bytes / 1024.0;
             $i++;
         }
 
         // Ensure $i is within bounds
         $i = \min($i, \count($units) - 1);
 
-        return \round($bytes, 1) . ' ' . $units[$i];
+        return (string) \round($bytes, 1) . ' ' . $units[$i];
     }
 
     /**

--- a/src/Console/Renderer/GenerateCommandRenderer.php
+++ b/src/Console/Renderer/GenerateCommandRenderer.php
@@ -157,6 +157,12 @@ final readonly class GenerateCommandRenderer
             ];
         } catch (\Throwable $e) {
             // If we can't read the file, return null to avoid errors
+            $this->output->writeln(\sprintf(
+                '<fg=yellow>%s Warning:</> Could not read file statistics for %s: %s',
+                self::WARNING_SYMBOL,
+                $outputPath,
+                $e->getMessage()
+            ));
             return null;
         }
     }
@@ -170,7 +176,7 @@ final readonly class GenerateCommandRenderer
         $i = 0;
 
         while ($bytes >= 1024 && $i < \count($units) - 1) {
-            $bytes /= 1024;
+            $bytes = (float) $bytes / 1024;
             $i++;
         }
 

--- a/src/Lib/Content/Block/FileStatsBlock.php
+++ b/src/Lib/Content/Block/FileStatsBlock.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Content\Block;
+
+use Butschster\ContextGenerator\Lib\Content\Renderer\RendererInterface;
+
+/**
+ * Block for file statistics (size, line count, etc.)
+ */
+final readonly class FileStatsBlock extends AbstractBlock
+{
+    public function __construct(
+        string $content,
+        private int $fileSize,
+        private int $lineCount,
+        private ?string $filePath = null,
+    ) {
+        parent::__construct($content);
+    }
+
+    public function render(RendererInterface $renderer): string
+    {
+        return $renderer->renderFileStatsBlock($this);
+    }
+
+    public function getFileSize(): int
+    {
+        return $this->fileSize;
+    }
+
+    public function getLineCount(): int
+    {
+        return $this->lineCount;
+    }
+
+    public function getFilePath(): ?string
+    {
+        return $this->filePath;
+    }
+
+    public function formatSize(int $bytes): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB'];
+        $i = 0;
+
+        while ($bytes >= 1024 && $i < \count($units) - 1) {
+            $bytes /= 1024;
+            $i++;
+        }
+
+        // Ensure $i is within bounds
+        $i = \min($i, \count($units) - 1);
+
+        return \round($bytes, 2) . ' ' . $units[$i];
+    }
+}

--- a/src/Lib/Content/Block/FileStatsBlock.php
+++ b/src/Lib/Content/Block/FileStatsBlock.php
@@ -46,13 +46,13 @@ final readonly class FileStatsBlock extends AbstractBlock
         $i = 0;
 
         while ($bytes >= 1024 && $i < \count($units) - 1) {
-            $bytes = (float) $bytes / 1024;
+            $bytes = (float) $bytes / 1024.0;
             $i++;
         }
 
         // Ensure $i is within bounds
         $i = \min($i, \count($units) - 1);
 
-        return \round($bytes, 2) . ' ' . $units[$i];
+        return (string) \round($bytes, 2) . ' ' . $units[$i];
     }
 }

--- a/src/Lib/Content/Block/FileStatsBlock.php
+++ b/src/Lib/Content/Block/FileStatsBlock.php
@@ -46,7 +46,7 @@ final readonly class FileStatsBlock extends AbstractBlock
         $i = 0;
 
         while ($bytes >= 1024 && $i < \count($units) - 1) {
-            $bytes /= 1024;
+            $bytes = (float) $bytes / 1024;
             $i++;
         }
 

--- a/src/Lib/Content/ContentBuilder.php
+++ b/src/Lib/Content/ContentBuilder.php
@@ -12,6 +12,7 @@ use Butschster\ContextGenerator\Lib\Content\Block\SeparatorBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TextBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TitleBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TreeViewBlock;
+use Butschster\ContextGenerator\Lib\Content\Block\FileStatsBlock;
 use Butschster\ContextGenerator\Lib\Content\Renderer\MarkdownRenderer;
 use Butschster\ContextGenerator\Lib\Content\Renderer\RendererInterface;
 
@@ -121,6 +122,18 @@ final class ContentBuilder implements \Stringable
     public function addTreeView(string $treeView): self
     {
         return $this->addBlock(new TreeViewBlock($treeView));
+    }
+
+    /**
+     * Add a file stats block
+     *
+     * @param int $fileSize The file size in bytes
+     * @param int $lineCount The number of lines in the file
+     * @param string|null $filePath The file path (optional)
+     */
+    public function addFileStats(int $fileSize, int $lineCount, ?string $filePath = null): self
+    {
+        return $this->addBlock(new FileStatsBlock('', $fileSize, $lineCount, $filePath));
     }
 
     /**

--- a/src/Lib/Content/Renderer/MarkdownRenderer.php
+++ b/src/Lib/Content/Renderer/MarkdownRenderer.php
@@ -11,6 +11,7 @@ use Butschster\ContextGenerator\Lib\Content\Block\SeparatorBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TextBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TitleBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TreeViewBlock;
+use Butschster\ContextGenerator\Lib\Content\Block\FileStatsBlock;
 
 /**
  * Renderer for Markdown format
@@ -75,6 +76,22 @@ final class MarkdownRenderer extends AbstractRenderer
             return '';
         }
         return \sprintf("```\n// Structure of documents\n%s\n```\n\n", $content);
+    }
+
+    public function renderFileStatsBlock(FileStatsBlock $block): string
+    {
+        $filePath = $block->getFilePath() ? "File: `{$block->getFilePath()}`\n" : '';
+        $size = $block->formatSize($block->getFileSize());
+        $lineCount = $block->getLineCount();
+
+        return <<<STATS
+        ---
+        **File Statistics**
+        - **Size**: {$size}
+        - **Lines**: {$lineCount}
+        {$filePath}
+        \n\n
+        STATS;
     }
 
     public function renderSeparatorBlock(SeparatorBlock $block): string

--- a/src/Lib/Content/Renderer/RendererInterface.php
+++ b/src/Lib/Content/Renderer/RendererInterface.php
@@ -11,6 +11,7 @@ use Butschster\ContextGenerator\Lib\Content\Block\SeparatorBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TextBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TitleBlock;
 use Butschster\ContextGenerator\Lib\Content\Block\TreeViewBlock;
+use Butschster\ContextGenerator\Lib\Content\Block\FileStatsBlock;
 
 /**
  * Interface for content renderers
@@ -41,6 +42,11 @@ interface RendererInterface
      * Render a tree view block
      */
     public function renderTreeViewBlock(TreeViewBlock $block): string;
+
+    /**
+     * Render a file stats block
+     */
+    public function renderFileStatsBlock(FileStatsBlock $block): string;
 
     /**
      * Render a separator block

--- a/tests/src/Unit/Document/Compiler/DocumentCompilerTest.php
+++ b/tests/src/Unit/Document/Compiler/DocumentCompilerTest.php
@@ -38,8 +38,10 @@ final class DocumentCompilerTest extends TestCase
         );
 
         $this->files
-            ->expects($this->never())
-            ->method('exists');
+            ->expects($this->once())
+            ->method('exists')
+            ->with('/base/path/output.txt')
+            ->willReturn(false);
 
         $this->files
             ->expects($this->once())
@@ -102,8 +104,10 @@ final class DocumentCompilerTest extends TestCase
         $document = $document->addSource($source);
 
         $this->files
-            ->expects($this->never())
-            ->method('exists');
+            ->expects($this->once())
+            ->method('exists')
+            ->with('/base/path/output.txt')
+            ->willReturn(false);
 
         $compiled = $this->compiler->compile($document);
 
@@ -122,7 +126,7 @@ final class DocumentCompilerTest extends TestCase
         )->addTag(...['tag1', 'tag2']);
 
         $this->files
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('exists')
             ->with('/base/path/output.txt')
             ->willReturn(false);
@@ -163,8 +167,10 @@ final class DocumentCompilerTest extends TestCase
         $document = $document->addSource($source1)->addSource($source2);
 
         $this->files
-            ->expects($this->never())
-            ->method('exists');
+            ->expects($this->once())
+            ->method('exists')
+            ->with('/base/path/output.txt')
+            ->willReturn(false);
 
         $this->files
             ->expects($this->once())


### PR DESCRIPTION
This PR includes:
- Add FileStatsBlock content block type for displaying file size and line count
- Update DocumentCompiler to include file statistics in generated content
- Update GenerateCommandRenderer to show file statistics in console output
- Display human-readable file sizes (B, KB, MB, GB) and line counts
- Add statistics section at the end of each generated markdown file

Related Issue: #249 