### PR TITLE
feat: add directory existence and writability validation to init command

### DIFF
--- a/src/Template/Console/InitCommand.php
+++ b/src/Template/Console/InitCommand.php
@@ -312,7 +312,7 @@ final class InitCommand extends BaseCommand
                 $this->output->note('Please check directory permissions or run with appropriate privileges.');
                 return false;
             }
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             // If we can't check permissions, assume it's not writable
             $this->output->error(\sprintf('Cannot check directory permissions: %s', $directory));
             $this->output->note('Please ensure the directory is writable or run with appropriate privileges.');


### PR DESCRIPTION
- Add validateDirectoryForWriting() method to check if target directory exists
- Validate directory writability using permission bits before file creation

not really sure about the psalm errors for this one too.

Related Issue: #248 