### PR TITLE
Add Variable Resolution in Source Paths and New Path Variables

### DIFF
--- a/context.yaml
+++ b/context.yaml
@@ -26,44 +26,9 @@ documents:
           - '*Interface.php'
         showTreeView: true
 
-  - description: Project Templates
-    outputPath: core/templates.md
-    sources:
-      - type: file
-        sourcePaths:
-          - src/Template
-          - vendor/spiral/files/src/FilesInterface.php
-        showTreeView: true
-
-  - description: Research Templates
-    outputPath: core/drafling.md
-    sources:
-      - type: file
-        sourcePaths:
-          - src/Research/Config
-          - src/Research/Domain
-          - src/Research/Repository
-          - src/Research/Service
-          - src/Research/Storage/StorageDriverInterface.php
-
-  - description: Research FileStorage
-    outputPath: drafling/file-storage.md
-    sources:
-      - type: file
-        sourcePaths:
-          - src/Research/Storage
-
-  - description: Research MCP
-    outputPath: drafling/mcp.md
-    sources:
-      - type: file
-        sourcePaths:
-          - src/Research/MCP
-          - src/McpServer/McpServerBootloader.php
-
-
   - description: "Changes in the Project"
     outputPath: "changes.md"
     sources:
       - type: git_diff
         commit: unstaged
+

--- a/src/Config/Import/ImportResolver.php
+++ b/src/Config/Import/ImportResolver.php
@@ -9,8 +9,8 @@ use Butschster\ContextGenerator\Config\Exception\ConfigLoaderException;
 use Butschster\ContextGenerator\Config\Import\Merger\ConfigMergerProviderInterface;
 use Butschster\ContextGenerator\Config\Import\PathPrefixer\DocumentOutputPathPrefixer;
 use Butschster\ContextGenerator\Config\Import\PathPrefixer\SourcePathPrefixer;
-use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigInterface;
 use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigFactory;
+use Butschster\ContextGenerator\Config\Import\Source\Config\SourceConfigInterface;
 use Butschster\ContextGenerator\Config\Import\Source\Exception\ImportSourceException;
 use Butschster\ContextGenerator\Config\Import\Source\ImportedConfig;
 use Butschster\ContextGenerator\Config\Import\Source\ImportSourceProvider;
@@ -31,8 +31,8 @@ final readonly class ImportResolver
         private ImportSourceProvider $sourceProvider,
         private WildcardPathFinder $pathFinder,
         private ConfigMergerProviderInterface $configMergerProvider,
-        private DocumentOutputPathPrefixer $documentPrefixer = new DocumentOutputPathPrefixer(),
-        private SourcePathPrefixer $sourcePrefixer = new SourcePathPrefixer(),
+        private DocumentOutputPathPrefixer $documentPrefixer,
+        private SourcePathPrefixer $sourcePrefixer,
         private SourceConfigFactory $sourceConfigFactory = new SourceConfigFactory(),
         private CircularImportDetectorInterface $detector = new CircularImportDetector(),
         #[LoggerPrefix(prefix: 'import-resolver')]

--- a/src/Config/Import/PathPrefixer/PathPrefixer.php
+++ b/src/Config/Import/PathPrefixer/PathPrefixer.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Config\Import\PathPrefixer;
 
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
+
 /**
  * Abstract base class for path prefix operations
  */
 abstract readonly class PathPrefixer
 {
+    public function __construct(
+        protected VariableResolver $variables,
+    ) {}
+
     /**
      * Apply a path prefix to the appropriate paths in a configuration
      */
@@ -20,6 +26,7 @@ abstract readonly class PathPrefixer
     protected function combinePaths(string $prefix, string $path): string
     {
         $combined = \rtrim($prefix, '/') . '/' . \ltrim($path, '/');
+
         return $this->normalizePath($combined);
     }
 

--- a/src/Config/Import/PathPrefixer/SourcePathPrefixer.php
+++ b/src/Config/Import/PathPrefixer/SourcePathPrefixer.php
@@ -58,10 +58,13 @@ final readonly class SourcePathPrefixer extends PathPrefixer
     private function applyPrefixToPaths(mixed $paths, string $prefix): mixed
     {
         if (\is_string($paths)) {
+            $paths = $this->variables->resolve($paths);
+
             // Skip absolute paths
             if ($this->isAbsolutePath($paths)) {
                 return $paths;
             }
+
             return $this->combinePaths($prefix, $paths);
         }
 

--- a/src/Lib/Variable/Provider/PredefinedVariableProvider.php
+++ b/src/Lib/Variable/Provider/PredefinedVariableProvider.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Lib\Variable\Provider;
 
+use Butschster\ContextGenerator\DirectoriesInterface;
+
 /**
  * Provider with predefined system variables
  */
 final readonly class PredefinedVariableProvider implements VariableProviderInterface
 {
+    public function __construct(
+        private DirectoriesInterface $dirs,
+    ) {}
+
     public function has(string $name): bool
     {
         return \array_key_exists($name, $this->getPredefinedVariables());
@@ -37,6 +43,11 @@ final readonly class PredefinedVariableProvider implements VariableProviderInter
             'OS' => PHP_OS,
             'HOSTNAME' => \gethostname() ?: 'unknown',
             'PWD' => \getcwd() ?: '.',
+
+            'ROOT_PATH' => (string) $this->dirs->getRootPath(),
+            'CONFIG_PATH' => (string) $this->dirs->getConfigPath(),
+            'ENV_PATH' => (string) $this->dirs->getEnvFilePath(),
+            'BINARY_PATH' => (string) $this->dirs->getBinaryPath(),
         ];
     }
 }

--- a/src/Lib/Variable/VariableBootloader.php
+++ b/src/Lib/Variable/VariableBootloader.php
@@ -49,7 +49,7 @@ final class VariableBootloader extends Bootloader
                     ),
 
                     // Predefined system variables have lowest priority
-                    new PredefinedVariableProvider(),
+                    new PredefinedVariableProvider(dirs: $dirs),
                 );
             },
 

--- a/src/Lib/Variable/VariableReplacementProcessor.php
+++ b/src/Lib/Variable/VariableReplacementProcessor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Butschster\ContextGenerator\Lib\Variable;
 
 use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
-use Butschster\ContextGenerator\Lib\Variable\Provider\PredefinedVariableProvider;
 use Butschster\ContextGenerator\Lib\Variable\Provider\VariableProviderInterface;
 use Psr\Log\LoggerInterface;
 
@@ -15,7 +14,7 @@ use Psr\Log\LoggerInterface;
 final readonly class VariableReplacementProcessor implements VariableReplacementProcessorInterface
 {
     public function __construct(
-        private VariableProviderInterface $provider = new PredefinedVariableProvider(),
+        private VariableProviderInterface $provider,
         #[LoggerPrefix(prefix: 'variable-replacement')]
         private ?LoggerInterface $logger = null,
     ) {}

--- a/src/Lib/Variable/VariableReplacementProcessor.php
+++ b/src/Lib/Variable/VariableReplacementProcessor.php
@@ -7,6 +7,7 @@ namespace Butschster\ContextGenerator\Lib\Variable;
 use Butschster\ContextGenerator\Application\Logger\LoggerPrefix;
 use Butschster\ContextGenerator\Lib\Variable\Provider\VariableProviderInterface;
 use Psr\Log\LoggerInterface;
+use Spiral\Core\Attribute\Proxy;
 
 /**
  * Processor that replaces variable references in text
@@ -14,6 +15,7 @@ use Psr\Log\LoggerInterface;
 final readonly class VariableReplacementProcessor implements VariableReplacementProcessorInterface
 {
     public function __construct(
+        #[Proxy]
         private VariableProviderInterface $provider,
         #[LoggerPrefix(prefix: 'variable-replacement')]
         private ?LoggerInterface $logger = null,

--- a/tests/src/Feature/Console/GenerateCommand/CompilingResult.php
+++ b/tests/src/Feature/Console/GenerateCommand/CompilingResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Console\GenerateCommand;
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 /**
  * Wrapper for generate command result assertions

--- a/tests/src/Feature/Console/GenerateCommand/ToolAssertions.php
+++ b/tests/src/Feature/Console/GenerateCommand/ToolAssertions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Console\GenerateCommand;
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 /**
  * Trait providing tool assertion methods for CompilingResult

--- a/tests/src/Feature/Research/Storage/FileStorage/DirectoryScannerTest.php
+++ b/tests/src/Feature/Research/Storage/FileStorage/DirectoryScannerTest.php
@@ -6,7 +6,7 @@ namespace Tests\Feature\Drafling\Storage\FileStorage;
 
 use Butschster\ContextGenerator\Research\Storage\FileStorage\DirectoryScanner;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 use Spiral\Exceptions\ExceptionReporterInterface;
 use Spiral\Files\Files;
 

--- a/tests/src/Feature/Research/Storage/FileStorage/DirectoryScannerTest.php
+++ b/tests/src/Feature/Research/Storage/FileStorage/DirectoryScannerTest.php
@@ -245,6 +245,7 @@ MARKDOWN;
         $this->scanner = new DirectoryScanner($files, $reporter);
     }
 
+    #[\Override]
     protected function tearDown(): void
     {
         // Clean up temp directory

--- a/tests/src/Feature/Research/Storage/FileStorage/FrontmatterParserTest.php
+++ b/tests/src/Feature/Research/Storage/FileStorage/FrontmatterParserTest.php
@@ -6,7 +6,7 @@ namespace Tests\Feature\Drafling\Storage\FileStorage;
 
 use Butschster\ContextGenerator\Research\Storage\FileStorage\FrontmatterParser;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 final class FrontmatterParserTest extends TestCase
 {

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests;
 
 use Butschster\ContextGenerator\Directories;
+use Butschster\ContextGenerator\DirectoriesInterface;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
@@ -25,6 +26,11 @@ abstract class TestCase extends BaseTestCase
      * @var array<string> Temporary directories to clean up
      */
     private array $tempDirs = [];
+
+    public function getDirs(): DirectoriesInterface
+    {
+        return $this->createDirectories();
+    }
 
     /**
      * Clean up temporary files and directories

--- a/tests/src/Unit/Application/FSPathLinuxTest.php
+++ b/tests/src/Unit/Application/FSPathLinuxTest.php
@@ -8,7 +8,7 @@ use Butschster\ContextGenerator\Application\FSPath;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(FSPath::class)]
 final class FSPathLinuxTest extends TestCase

--- a/tests/src/Unit/Application/FSPathLinuxTest.php
+++ b/tests/src/Unit/Application/FSPathLinuxTest.php
@@ -265,6 +265,7 @@ final class FSPathLinuxTest extends TestCase
         }
     }
 
+    #[\Override]
     protected function tearDown(): void
     {
         // Reset directory separator if it was overridden

--- a/tests/src/Unit/Application/FSPathMixedSlashTest.php
+++ b/tests/src/Unit/Application/FSPathMixedSlashTest.php
@@ -220,6 +220,7 @@ final class FSPathMixedSlashTest extends TestCase
         $this->assertSame('C:/Users/test/documents/file.txt', $path->toString());
     }
 
+    #[\Override]
     protected function tearDown(): void
     {
         // Always reset directory separator at the end of each test

--- a/tests/src/Unit/Application/FSPathMixedSlashTest.php
+++ b/tests/src/Unit/Application/FSPathMixedSlashTest.php
@@ -8,7 +8,7 @@ use Butschster\ContextGenerator\Application\FSPath;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(FSPath::class)]
 final class FSPathMixedSlashTest extends TestCase

--- a/tests/src/Unit/Application/FSPathWindowsTest.php
+++ b/tests/src/Unit/Application/FSPathWindowsTest.php
@@ -218,6 +218,7 @@ final class FSPathWindowsTest extends TestCase
         }
     }
 
+    #[\Override]
     protected function tearDown(): void
     {
         // Reset directory separator if it was overridden

--- a/tests/src/Unit/Application/FSPathWindowsTest.php
+++ b/tests/src/Unit/Application/FSPathWindowsTest.php
@@ -8,7 +8,7 @@ use Butschster\ContextGenerator\Application\FSPath;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(FSPath::class)]
 final class FSPathWindowsTest extends TestCase

--- a/tests/src/Unit/Fetcher/FileSourceFetcherTest.php
+++ b/tests/src/Unit/Fetcher/FileSourceFetcherTest.php
@@ -10,7 +10,7 @@ use Butschster\ContextGenerator\Modifier\SourceModifierRegistry;
 use Butschster\ContextGenerator\Source\File\FileSourceFetcher;
 use Butschster\ContextGenerator\Source\SourceInterface;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class FileSourceFetcherTest extends TestCase
 {

--- a/tests/src/Unit/Fetcher/FileTreeBuilderTest.php
+++ b/tests/src/Unit/Fetcher/FileTreeBuilderTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Fetcher;
 
 use Butschster\ContextGenerator\Lib\TreeBuilder\FileTreeBuilder;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class FileTreeBuilderTest extends TestCase
 {

--- a/tests/src/Unit/Fetcher/TextSourceFetcherTest.php
+++ b/tests/src/Unit/Fetcher/TextSourceFetcherTest.php
@@ -9,7 +9,7 @@ use Butschster\ContextGenerator\Source\SourceInterface;
 use Butschster\ContextGenerator\Source\Text\TextSource;
 use Butschster\ContextGenerator\Source\Text\TextSourceFetcher;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class TextSourceFetcherTest extends TestCase
 {

--- a/tests/src/Unit/Lib/Html/HtmlCleanerTest.php
+++ b/tests/src/Unit/Lib/Html/HtmlCleanerTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Lib\Html;
 use Butschster\ContextGenerator\Lib\Html\HtmlCleaner;
 use League\HTMLToMarkdown\HtmlConverter;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class HtmlCleanerTest extends TestCase
 {

--- a/tests/src/Unit/Lib/TreeBuilder/DirectorySorterTest.php
+++ b/tests/src/Unit/Lib/TreeBuilder/DirectorySorterTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Lib\TreeBuilder;
 use Butschster\ContextGenerator\Lib\TreeBuilder\DirectorySorter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(DirectorySorter::class)]
 final class DirectorySorterTest extends TestCase

--- a/tests/src/Unit/Lib/TreeBuilder/FileTreeBuilderTest.php
+++ b/tests/src/Unit/Lib/TreeBuilder/FileTreeBuilderTest.php
@@ -8,7 +8,7 @@ use Butschster\ContextGenerator\Lib\TreeBuilder\FileTreeBuilder;
 use Butschster\ContextGenerator\Lib\TreeBuilder\TreeRendererInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(FileTreeBuilder::class)]
 final class FileTreeBuilderTest extends TestCase

--- a/tests/src/Unit/Lib/TreeBuilder/FileTreeBuilderTest.php
+++ b/tests/src/Unit/Lib/TreeBuilder/FileTreeBuilderTest.php
@@ -261,6 +261,7 @@ final class FileTreeBuilderTest extends TestCase
         \file_put_contents($this->tempDir . '/dir2/subdir/file4.txt', 'content');
     }
 
+    #[\Override]
     protected function tearDown(): void
     {
         $this->removeDirectory($this->tempDir);

--- a/tests/src/Unit/Lib/Variable/Provider/CompositeVariableProviderTest.php
+++ b/tests/src/Unit/Lib/Variable/Provider/CompositeVariableProviderTest.php
@@ -8,7 +8,7 @@ use Butschster\ContextGenerator\Lib\Variable\Provider\CompositeVariableProvider;
 use Butschster\ContextGenerator\Lib\Variable\Provider\VariableProviderInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(CompositeVariableProvider::class)]
 class CompositeVariableProviderTest extends TestCase

--- a/tests/src/Unit/Lib/Variable/Provider/DotEnvVariableProviderTest.php
+++ b/tests/src/Unit/Lib/Variable/Provider/DotEnvVariableProviderTest.php
@@ -8,7 +8,7 @@ use Butschster\ContextGenerator\Lib\Variable\Provider\DotEnvVariableProvider;
 use Dotenv\Repository\RepositoryInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(DotEnvVariableProvider::class)]
 class DotEnvVariableProviderTest extends TestCase

--- a/tests/src/Unit/Lib/Variable/Provider/PredefinedVariableProviderTest.php
+++ b/tests/src/Unit/Lib/Variable/Provider/PredefinedVariableProviderTest.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Lib\Variable\Provider;
 use Butschster\ContextGenerator\Lib\Variable\Provider\PredefinedVariableProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(PredefinedVariableProvider::class)]
 class PredefinedVariableProviderTest extends TestCase
@@ -83,6 +83,6 @@ class PredefinedVariableProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->provider = new PredefinedVariableProvider();
+        $this->provider = new PredefinedVariableProvider(dirs: $this->getDirs());
     }
 }

--- a/tests/src/Unit/Lib/Variable/VariableReplacementProcessorTest.php
+++ b/tests/src/Unit/Lib/Variable/VariableReplacementProcessorTest.php
@@ -9,7 +9,7 @@ use Butschster\ContextGenerator\Lib\Variable\VariableReplacementProcessor;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 use Psr\Log\LoggerInterface;
 
 #[CoversClass(VariableReplacementProcessor::class)]

--- a/tests/src/Unit/Lib/Variable/VariableResolverTest.php
+++ b/tests/src/Unit/Lib/Variable/VariableResolverTest.php
@@ -9,7 +9,7 @@ use Butschster\ContextGenerator\Lib\Variable\VariableReplacementProcessor;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(VariableResolver::class)]
 class VariableResolverTest extends TestCase

--- a/tests/src/Unit/Lib/Variable/VariableSystemIntegrationTest.php
+++ b/tests/src/Unit/Lib/Variable/VariableSystemIntegrationTest.php
@@ -98,7 +98,7 @@ class VariableSystemIntegrationTest extends TestCase
         $compositeProvider = new CompositeVariableProvider(
             $customProviderWithOverride,          // Highest priority
             $this->customProvider,               // Middle priority
-            new PredefinedVariableProvider(),    // Lowest priority
+            new PredefinedVariableProvider(dirs: $this->getDirs()),    // Lowest priority
         );
 
         $processor = new VariableReplacementProcessor($compositeProvider);
@@ -180,7 +180,7 @@ class VariableSystemIntegrationTest extends TestCase
 
         // Create a composite provider with predefined variables and our custom provider
         $compositeProvider = new CompositeVariableProvider(
-            new PredefinedVariableProvider(),  // Lower priority (system variables)
+            new PredefinedVariableProvider(dirs: $this->getDirs()),  // Lower priority (system variables)
             $this->customProvider,              // Higher priority (custom variables)
         );
 

--- a/tests/src/Unit/Source/GitDiff/Fetcher/Source/GitSourceTestCase.php
+++ b/tests/src/Unit/Source/GitDiff/Fetcher/Source/GitSourceTestCase.php
@@ -7,7 +7,7 @@ namespace Tests\Unit\Source\GitDiff\Fetcher\Source;
 use Butschster\ContextGenerator\Lib\Git\Command;
 use Butschster\ContextGenerator\Lib\Git\CommandsExecutorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 

--- a/tests/src/Unit/Source/GitDiff/RenderStrategy/LLMFriendlyRenderStrategyTest.php
+++ b/tests/src/Unit/Source/GitDiff/RenderStrategy/LLMFriendlyRenderStrategyTest.php
@@ -10,7 +10,7 @@ use Butschster\ContextGenerator\Source\GitDiff\RenderStrategy\Enum\RenderStrateg
 use Butschster\ContextGenerator\Source\GitDiff\RenderStrategy\LLMFriendlyRenderStrategy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(LLMFriendlyRenderStrategy::class)]
 final class LLMFriendlyRenderStrategyTest extends TestCase

--- a/tests/src/Unit/Source/GitDiff/RenderStrategy/RawRenderStrategyTest.php
+++ b/tests/src/Unit/Source/GitDiff/RenderStrategy/RawRenderStrategyTest.php
@@ -10,7 +10,7 @@ use Butschster\ContextGenerator\Source\GitDiff\RenderStrategy\Enum\RenderStrateg
 use Butschster\ContextGenerator\Source\GitDiff\RenderStrategy\RawRenderStrategy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(RawRenderStrategy::class)]
 final class RawRenderStrategyTest extends TestCase

--- a/tests/src/Unit/Source/GitDiff/RenderStrategy/RenderStrategyFactoryTest.php
+++ b/tests/src/Unit/Source/GitDiff/RenderStrategy/RenderStrategyFactoryTest.php
@@ -11,7 +11,7 @@ use Butschster\ContextGenerator\Source\GitDiff\RenderStrategy\RenderStrategyFact
 use Butschster\ContextGenerator\Source\GitDiff\RenderStrategy\RenderStrategyInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 #[CoversClass(RenderStrategyFactory::class)]
 final class RenderStrategyFactoryTest extends TestCase

--- a/tests/src/Unit/Source/Url/UrlSourceFetcherTest.php
+++ b/tests/src/Unit/Source/Url/UrlSourceFetcherTest.php
@@ -9,6 +9,7 @@ use Butschster\ContextGenerator\Lib\Html\HtmlCleanerInterface;
 use Butschster\ContextGenerator\Lib\Html\SelectorContentExtractorInterface;
 use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
 use Butschster\ContextGenerator\Lib\HttpClient\HttpResponse;
+use Butschster\ContextGenerator\Lib\Variable\Provider\PredefinedVariableProvider;
 use Butschster\ContextGenerator\Lib\Variable\VariableReplacementProcessor;
 use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
@@ -18,8 +19,8 @@ use Butschster\ContextGenerator\Source\Url\UrlSourceFetcher;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Tests\TestCase;
 
 #[CoversClass(UrlSourceFetcher::class)]
 class UrlSourceFetcherTest extends TestCase
@@ -316,7 +317,7 @@ class UrlSourceFetcherTest extends TestCase
     {
         $this->httpClient = $this->createMock(HttpClientInterface::class);
         $this->variableResolver = new VariableResolver(
-            new VariableReplacementProcessor(),
+            new VariableReplacementProcessor(new PredefinedVariableProvider(dirs: $this->getDirs())),
         );
         $this->cleaner = $this->createMock(HtmlCleanerInterface::class);
         $this->selectorExtractor = $this->createMock(SelectorContentExtractorInterface::class);


### PR DESCRIPTION
This PR enhances CTX's variable system by enabling variable resolution in source paths and adding new predefined path variables. This makes configurations more flexible, reusable, and suitable for multi-environment setups.

## Changes

### 1. Variable Resolution in Source Paths

Source paths now support variable substitution, allowing dynamic path construction:

**Before:**

```yaml
documents:
  - description: "API Documentation"
    sources:
      - type: file
        sourcePaths:
          - "src/Controllers"  # Static path only
```

**After:**

```yaml
variables:
  env: production
  src_dir: src/{{env}}

documents:
  - description: "API Documentation"
    sources:
      - type: file
        sourcePaths:
          - "{{src_dir}}/Controllers"  # Dynamic path based on environment
          - "${ROOT_PATH}/config" # Using predefined variables
```

### 2. New Predefined Path Variables

Added four new predefined variables for project paths:

|Variable|Description|Example|
|---|---|---|
|`${ROOT_PATH}`|Project root directory|`/home/user/my-project`|
|`${CONFIG_PATH}`|Configuration file path|`/home/user/my-project/context.yaml`|
|`${ENV_PATH}`|Environment file path|`/home/user/my-project/.env.local`|
|`${BINARY_PATH}`|CTX binary path|`/usr/local/bin/ctx`|
