### PR TITLE
feat: add FileInsertContent and FileDeleteContent MCP tools for line-based file operations

### DIFF
--- a/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/Dto/DeletionItem.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/Dto/DeletionItem.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileDeleteContent\Dto;
+
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+
+/**
+ * Represents a single deletion operation - either a single line or a range.
+ */
+final readonly class DeletionItem
+{
+    public function __construct(
+        #[Field(
+            description: '1-based line number for single line deletion, or start of range.',
+        )]
+        public int $line,
+        #[Field(
+            description: 'Optional end line for range deletion. If null, only the single line is deleted. When specified, all lines from `line` to `to` (inclusive) will be deleted.',
+        )]
+        public ?int $to = null,
+    ) {}
+
+    /**
+     * Get all line numbers this item represents.
+     *
+     * @return int[]
+     */
+    public function getLineNumbers(): array
+    {
+        if ($this->to === null) {
+            return [$this->line];
+        }
+
+        $start = \min($this->line, $this->to);
+        $end = \max($this->line, $this->to);
+
+        return \range($start, $end);
+    }
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/Dto/FileDeleteContentRequest.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/Dto/FileDeleteContentRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileDeleteContent\Dto;
+
+use Butschster\ContextGenerator\McpServer\Project\ProjectAwareRequest;
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+
+final readonly class FileDeleteContentRequest implements ProjectAwareRequest
+{
+    /**
+     * @param DeletionItem[] $lines
+     */
+    public function __construct(
+        #[Field(
+            description: 'Path to the file, relative to project root. Only files within project directory can be accessed.',
+        )]
+        public string $path,
+        #[Field(
+            description: 'Lines to delete. Each item can specify a single line or a range. Examples: [{"line": 5}, {"line": 10}] for individual lines, or [{"line": 5, "to": 10}] for range deletion, or mixed: [{"line": 3}, {"line": 10, "to": 15}, {"line": 20}].',
+        )]
+        public array $lines,
+        #[Field(
+            description: 'Project identifier if multiple projects are supported. Optional.',
+        )]
+        public ?string $project = null,
+    ) {}
+
+    public function getProject(): ?string
+    {
+        return $this->project;
+    }
+
+    /**
+     * Parse and normalize line specifications into a flat array of line numbers.
+     *
+     * @return int[]
+     */
+    public function getLineNumbers(): array
+    {
+        $lineNumbers = [];
+
+        foreach ($this->lines as $item) {
+            foreach ($item->getLineNumbers() as $lineNumber) {
+                $lineNumbers[] = $lineNumber;
+            }
+        }
+
+        // Remove duplicates and sort
+        $lineNumbers = \array_unique($lineNumbers);
+        \sort($lineNumbers);
+
+        return $lineNumbers;
+    }
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/FileDeleteContentAction.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/FileDeleteContentAction.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileDeleteContent;
+
+use Butschster\ContextGenerator\McpServer\Action\ToolResult;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileDeleteContent\Dto\FileDeleteContentRequest;
+use Butschster\ContextGenerator\McpServer\Attribute\InputSchema;
+use Butschster\ContextGenerator\McpServer\Attribute\Tool;
+use Butschster\ContextGenerator\McpServer\Routing\Attribute\Post;
+use PhpMcp\Schema\Result\CallToolResult;
+use Psr\Log\LoggerInterface;
+
+/**
+ * MCP tool for deleting content at specific line numbers in files.
+ */
+#[Tool(
+    name: 'file-delete-content',
+    description: 'Delete specific line(s) from a file. Supports individual lines or ranges.',
+    title: 'File Delete Content',
+)]
+#[InputSchema(class: FileDeleteContentRequest::class)]
+final readonly class FileDeleteContentAction
+{
+    public function __construct(
+        private FileDeleteContentHandler $handler,
+        private LoggerInterface $logger,
+    ) {}
+
+    #[Post(path: '/tools/call/file-delete-content', name: 'tools.file-delete-content')]
+    public function __invoke(FileDeleteContentRequest $request): CallToolResult
+    {
+        $this->logger->info('Processing file-delete-content tool', [
+            'path' => $request->path,
+            'linesCount' => \count($request->lines),
+        ]);
+
+        // Validate required parameters
+        if (empty($request->path)) {
+            return ToolResult::error('Missing path parameter');
+        }
+
+        if (empty($request->lines)) {
+            return ToolResult::error('Missing lines parameter - must provide at least one line number or range');
+        }
+
+        try {
+            $result = $this->handler->handle($request);
+
+            if ($result->success) {
+                return ToolResult::text($result->message ?? 'Content deleted successfully');
+            }
+
+            return ToolResult::error($result->error ?? 'Unknown error occurred');
+        } catch (\Throwable $e) {
+            $this->logger->error('Error deleting content from file', [
+                'path' => $request->path,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return ToolResult::error(\sprintf(
+                "Failed to delete content: %s",
+                $e->getMessage(),
+            ));
+        }
+    }
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/FileDeleteContentHandler.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/FileDeleteContentHandler.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileDeleteContent;
+
+use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileDeleteContent\Dto\FileDeleteContentRequest;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileReplaceContent\LineEnding;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileReplaceContent\LineEndingNormalizer;
+use Psr\Log\LoggerInterface;
+use Spiral\Core\Attribute\Proxy;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Core handler for file content deletion operations.
+ *
+ * Handles line-based deletions with descending order processing to avoid offset issues.
+ */
+final readonly class FileDeleteContentHandler
+{
+    public function __construct(
+        private FilesInterface $files,
+        #[Proxy] private DirectoriesInterface $dirs,
+        private LineEndingNormalizer $normalizer,
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Execute the file content deletion operation.
+     */
+    public function handle(FileDeleteContentRequest $request): FileDeleteResult
+    {
+        $path = (string) $this->dirs->getRootPath()->join($request->path);
+
+        // Validate file exists
+        if (!$this->files->exists($path)) {
+            return FileDeleteResult::error(
+                \sprintf("File '%s' does not exist", $request->path),
+            );
+        }
+
+        // Validate not a directory
+        if ($this->files->isDirectory($path)) {
+            return FileDeleteResult::error(
+                \sprintf("'%s' is a directory, not a file", $request->path),
+            );
+        }
+
+        // Get line numbers
+        $lineNumbers = $request->getLineNumbers();
+
+        if ($lineNumbers === []) {
+            return FileDeleteResult::error(
+                'No valid line numbers provided. Specify line numbers as integers or ranges {"from": N, "to": M}.',
+            );
+        }
+
+        // Read file content
+        $content = $this->files->read($path);
+
+        // Detect the file's line ending style
+        $fileLineEnding = $this->normalizer->detect($content);
+
+        // Split content into lines
+        $lines = $this->splitIntoLines($content, $fileLineEnding);
+        $totalLines = \count($lines);
+
+        // Validate line numbers are within bounds
+        foreach ($lineNumbers as $lineNum) {
+            if ($lineNum < 1 || $lineNum > $totalLines) {
+                return FileDeleteResult::error(\sprintf(
+                    "Invalid line number %d. File has %d lines. Valid range: 1-%d.",
+                    $lineNum,
+                    $totalLines,
+                    $totalLines,
+                ));
+            }
+        }
+
+        // Sort in descending order to delete from bottom to top
+        // This way, deleting a line doesn't affect the indices of lines above it
+        $sortedLines = $lineNumbers;
+        \rsort($sortedLines);
+
+        // Delete lines and collect deleted content
+        $deletedContent = [];
+        foreach ($sortedLines as $lineNum) {
+            $index = $lineNum - 1; // Convert to 0-based index
+            $deletedContent[] = [
+                'line' => $lineNum,
+                'content' => $lines[$index],
+            ];
+            \array_splice($lines, $index, 1);
+        }
+
+        // Reverse to return in original (ascending) order
+        $deletedContent = \array_reverse($deletedContent);
+
+        // Rebuild file content
+        $newContent = \implode($fileLineEnding->value, $lines);
+
+        // Write back to file
+        $this->files->write($path, $newContent);
+
+        $deletedCount = \count($lineNumbers);
+
+        $this->logger->info('Successfully deleted content from file', [
+            'path' => $request->path,
+            'deletedLines' => $deletedCount,
+            'lineNumbers' => $lineNumbers,
+            'fileLineEnding' => $fileLineEnding->name,
+        ]);
+
+        // Build success message
+        $lineWord = $deletedCount === 1 ? 'line' : 'lines';
+        $message = \sprintf(
+            "Successfully deleted %d %s from file '%s'.",
+            $deletedCount,
+            $lineWord,
+            $request->path,
+        );
+
+        return FileDeleteResult::success(
+            message: $message,
+            deletedLines: $deletedCount,
+            deletedContent: $deletedContent,
+        );
+    }
+
+    /**
+     * Split content into lines, preserving empty lines.
+     *
+     * @return string[]
+     */
+    private function splitIntoLines(string $content, LineEnding $lineEnding): array
+    {
+        if ($content === '') {
+            return [''];
+        }
+
+        return \explode($lineEnding->value, $content);
+    }
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/FileDeleteResult.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileDeleteContent/FileDeleteResult.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileDeleteContent;
+
+/**
+ * Result DTO for file content deletion operations.
+ */
+final readonly class FileDeleteResult
+{
+    /**
+     * @param array<array{line: int, content: string}> $deletedContent
+     */
+    public function __construct(
+        public bool $success,
+        public ?string $message = null,
+        public ?string $error = null,
+        public int $deletedLines = 0,
+        public array $deletedContent = [],
+    ) {}
+
+    /**
+     * Create a successful result with deletion details.
+     *
+     * @param array<array{line: int, content: string}> $deletedContent
+     */
+    public static function success(
+        string $message,
+        int $deletedLines,
+        array $deletedContent,
+    ): self {
+        return new self(
+            success: true,
+            message: $message,
+            deletedLines: $deletedLines,
+            deletedContent: $deletedContent,
+        );
+    }
+
+    /**
+     * Create an error result with a message.
+     */
+    public static function error(string $message): self
+    {
+        return new self(
+            success: false,
+            error: $message,
+        );
+    }
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileInsertContent/Dto/FileInsertContentRequest.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileInsertContent/Dto/FileInsertContentRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent\Dto;
+
+use Butschster\ContextGenerator\McpServer\Project\ProjectAwareRequest;
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+
+final readonly class FileInsertContentRequest implements ProjectAwareRequest
+{
+    /**
+     * @param InsertionItem[] $insertions
+     */
+    public function __construct(
+        #[Field(
+            description: 'Path to the file, relative to project root. Only files within project directory can be accessed.',
+        )]
+        public string $path,
+        #[Field(
+            description: 'Array of insertions. Each insertion must have "line" (1-based line number, or -1 for end of file) and "content" (string to insert). Example: [{"line": 5, "content": "use App\\Service;"}]',
+        )]
+        public array $insertions,
+        #[Field(
+            description: 'Insert position relative to the specified line. Use "before" to insert before the line, "after" to insert after the line.',
+            default: 'after',
+        )]
+        public string $position = 'after',
+        #[Field(
+            description: 'Project identifier if multiple projects are supported. Optional.',
+        )]
+        public ?string $project = null,
+    ) {}
+
+    public function getProject(): ?string
+    {
+        return $this->project;
+    }
+
+    /**
+     * Get insertion items.
+     *
+     * @return InsertionItem[]
+     */
+    public function getInsertionItems(): array
+    {
+        return $this->insertions;
+    }
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileInsertContent/Dto/InsertionItem.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileInsertContent/Dto/InsertionItem.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent\Dto;
+
+use Spiral\JsonSchemaGenerator\Attribute\Field;
+
+/**
+ * Represents a single insertion operation with line number and content.
+ */
+final readonly class InsertionItem
+{
+    public function __construct(
+        #[Field(
+            description: '1-based line number where content should be inserted. Use -1 to insert at the end of the file.',
+        )]
+        public int $line,
+        #[Field(
+            description: 'Content to insert. Can be multiline (use \n for line breaks).',
+        )]
+        public string $content,
+    ) {}
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileInsertContent/FileInsertContentAction.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileInsertContent/FileInsertContentAction.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent;
+
+use Butschster\ContextGenerator\McpServer\Action\ToolResult;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent\Dto\FileInsertContentRequest;
+use Butschster\ContextGenerator\McpServer\Attribute\InputSchema;
+use Butschster\ContextGenerator\McpServer\Attribute\Tool;
+use Butschster\ContextGenerator\McpServer\Routing\Attribute\Post;
+use PhpMcp\Schema\Result\CallToolResult;
+use Psr\Log\LoggerInterface;
+
+/**
+ * MCP tool for inserting content at specific line numbers in files.
+ */
+#[Tool(
+    name: 'file-insert-content',
+    description: 'Insert content at specific line number(s) in a file. Supports single or batch insertions with automatic line offset calculation.',
+    title: 'File Insert Content',
+)]
+#[InputSchema(class: FileInsertContentRequest::class)]
+final readonly class FileInsertContentAction
+{
+    public function __construct(
+        private FileInsertContentHandler $handler,
+        private LoggerInterface $logger,
+    ) {}
+
+    #[Post(path: '/tools/call/file-insert-content', name: 'tools.file-insert-content')]
+    public function __invoke(FileInsertContentRequest $request): CallToolResult
+    {
+        $this->logger->info('Processing file-insert-content tool', [
+            'path' => $request->path,
+            'insertionsCount' => \count($request->insertions),
+            'position' => $request->position,
+        ]);
+
+        // Validate required parameters
+        if (empty($request->path)) {
+            return ToolResult::error('Missing path parameter');
+        }
+
+        if (empty($request->insertions)) {
+            return ToolResult::error('Missing insertions parameter - must provide at least one insertion');
+        }
+
+        try {
+            $result = $this->handler->handle($request);
+
+            if ($result->success) {
+                return ToolResult::text($result->message ?? 'Content inserted successfully');
+            }
+
+            return ToolResult::error($result->error ?? 'Unknown error occurred');
+        } catch (\Throwable $e) {
+            $this->logger->error('Error inserting content in file', [
+                'path' => $request->path,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return ToolResult::error(\sprintf(
+                "Failed to insert content: %s",
+                $e->getMessage(),
+            ));
+        }
+    }
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileInsertContent/FileInsertContentHandler.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileInsertContent/FileInsertContentHandler.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent;
+
+use Butschster\ContextGenerator\DirectoriesInterface;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent\Dto\FileInsertContentRequest;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent\Dto\InsertionItem;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileReplaceContent\LineEnding;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileReplaceContent\LineEndingNormalizer;
+use Psr\Log\LoggerInterface;
+use Spiral\Core\Attribute\Proxy;
+use Spiral\Files\FilesInterface;
+
+/**
+ * Core handler for file content insertion operations.
+ *
+ * Handles line-based insertions with automatic offset calculation for multiple insertions.
+ */
+final readonly class FileInsertContentHandler
+{
+    public function __construct(
+        private FilesInterface $files,
+        #[Proxy] private DirectoriesInterface $dirs,
+        private LineEndingNormalizer $normalizer,
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Execute the file content insertion operation.
+     */
+    public function handle(FileInsertContentRequest $request): FileInsertResult
+    {
+        $path = (string) $this->dirs->getRootPath()->join($request->path);
+
+        // Validate file exists
+        if (!$this->files->exists($path)) {
+            return FileInsertResult::error(
+                \sprintf("File '%s' does not exist", $request->path),
+            );
+        }
+
+        // Validate not a directory
+        if ($this->files->isDirectory($path)) {
+            return FileInsertResult::error(
+                \sprintf("'%s' is a directory, not a file", $request->path),
+            );
+        }
+
+        // Validate position parameter
+        if (!\in_array($request->position, ['before', 'after'], true)) {
+            return FileInsertResult::error(
+                "Invalid position parameter. Must be 'before' or 'after'.",
+            );
+        }
+
+        // Get insertion items
+        $insertionItems = $request->getInsertionItems();
+
+        if ($insertionItems === []) {
+            return FileInsertResult::error(
+                'No valid insertions provided. Each insertion must have "line" and "content" fields.',
+            );
+        }
+
+        // Read file content
+        $content = $this->files->read($path);
+
+        // Detect the file's line ending style
+        $fileLineEnding = $this->normalizer->detect($content);
+        $lineEndingStr = $fileLineEnding->value;
+
+        // Split content into lines
+        $lines = $this->splitIntoLines($content, $fileLineEnding);
+        $totalLines = \count($lines);
+
+        // Validate line numbers
+        foreach ($insertionItems as $item) {
+            if ($item->line !== -1 && ($item->line < 1 || $item->line > $totalLines)) {
+                return FileInsertResult::error(\sprintf(
+                    "Invalid line number %d. File has %d lines. Use 1-%d or -1 for end of file.",
+                    $item->line,
+                    $totalLines,
+                    $totalLines,
+                ));
+            }
+        }
+
+        // Sort insertions by line number (ascending) for proper offset calculation
+        $sortedItems = $this->sortInsertions($insertionItems, $totalLines);
+
+        // Process insertions with offset tracking
+        $offset = 0;
+        $insertionResults = [];
+        $totalLinesInserted = 0;
+
+        foreach ($sortedItems as $item) {
+            // Resolve line number (-1 means end of file)
+            $targetLine = $item->line === -1 ? $totalLines : $item->line;
+
+            // Apply offset from previous insertions
+            $actualLine = $targetLine + $offset;
+
+            // Normalize content line endings to match file
+            $normalizedContent = $this->normalizer->normalize($item->content, $fileLineEnding);
+
+            // Split inserted content into lines
+            $newLines = \explode($lineEndingStr, $normalizedContent);
+            $newLinesCount = \count($newLines);
+
+            // Calculate insert index (0-based)
+            $insertIndex = $request->position === 'after'
+                ? $actualLine
+                : $actualLine - 1;
+
+            // Ensure index is within bounds
+            $insertIndex = \max(0, \min($insertIndex, \count($lines)));
+
+            // Insert lines
+            \array_splice($lines, $insertIndex, 0, $newLines);
+
+            // Track results
+            $insertionResults[] = [
+                'line' => $item->line,
+                'linesInserted' => $newLinesCount,
+            ];
+
+            // Update offset for next insertion
+            $offset += $newLinesCount;
+            $totalLinesInserted += $newLinesCount;
+        }
+
+        // Rebuild file content
+        $newContent = \implode($lineEndingStr, $lines);
+
+        // Write back to file
+        $this->files->write($path, $newContent);
+
+        $this->logger->info('Successfully inserted content in file', [
+            'path' => $request->path,
+            'position' => $request->position,
+            'totalInsertions' => \count($insertionItems),
+            'totalLinesInserted' => $totalLinesInserted,
+            'fileLineEnding' => $fileLineEnding->name,
+        ]);
+
+        // Build success message
+        $locationWord = \count($insertionItems) === 1 ? 'location' : 'locations';
+        $message = \sprintf(
+            "Successfully inserted %d line(s) across %d %s in file '%s'.",
+            $totalLinesInserted,
+            \count($insertionItems),
+            $locationWord,
+            $request->path,
+        );
+
+        return FileInsertResult::success(
+            message: $message,
+            totalLinesInserted: $totalLinesInserted,
+            totalInsertions: \count($insertionItems),
+            insertions: $insertionResults,
+        );
+    }
+
+    /**
+     * Split content into lines, preserving empty lines.
+     *
+     * @return string[]
+     */
+    private function splitIntoLines(string $content, LineEnding $lineEnding): array
+    {
+        if ($content === '') {
+            return [''];
+        }
+
+        return \explode($lineEnding->value, $content);
+    }
+
+    /**
+     * Sort insertions by line number ascending, resolving -1 to actual line number.
+     *
+     * @param InsertionItem[] $items
+     * @return InsertionItem[]
+     */
+    private function sortInsertions(array $items, int $totalLines): array
+    {
+        \usort($items, static function (InsertionItem $a, InsertionItem $b) use ($totalLines): int {
+            $lineA = $a->line === -1 ? $totalLines + 1 : $a->line;
+            $lineB = $b->line === -1 ? $totalLines + 1 : $b->line;
+
+            return $lineA <=> $lineB;
+        });
+
+        return $items;
+    }
+}

--- a/src/McpServer/Action/Tools/Filesystem/FileInsertContent/FileInsertResult.php
+++ b/src/McpServer/Action/Tools/Filesystem/FileInsertContent/FileInsertResult.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent;
+
+/**
+ * Result DTO for file content insertion operations.
+ */
+final readonly class FileInsertResult
+{
+    /**
+     * @param array<array{line: int, linesInserted: int}> $insertions
+     */
+    public function __construct(
+        public bool $success,
+        public ?string $message = null,
+        public ?string $error = null,
+        public int $totalLinesInserted = 0,
+        public int $totalInsertions = 0,
+        public array $insertions = [],
+    ) {}
+
+    /**
+     * Create a successful result with insertion details.
+     *
+     * @param array<array{line: int, linesInserted: int}> $insertions
+     */
+    public static function success(
+        string $message,
+        int $totalLinesInserted,
+        int $totalInsertions,
+        array $insertions,
+    ): self {
+        return new self(
+            success: true,
+            message: $message,
+            totalLinesInserted: $totalLinesInserted,
+            totalInsertions: $totalInsertions,
+            insertions: $insertions,
+        );
+    }
+
+    /**
+     * Create an error result with a message.
+     */
+    public static function error(string $message): self
+    {
+        return new self(
+            success: false,
+            error: $message,
+        );
+    }
+}

--- a/src/McpServer/ActionsBootloader.php
+++ b/src/McpServer/ActionsBootloader.php
@@ -22,6 +22,8 @@ use Butschster\ContextGenerator\McpServer\Action\Tools\Docs\LibrarySearchAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\ExecuteCustomToolAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\DirectoryListAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileRead\FileReadAction;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileDeleteContent\FileDeleteContentAction;
+use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileInsertContent\FileInsertContentAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileReplaceContent\FileReplaceContentAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileSearch\FileSearchAction;
 use Butschster\ContextGenerator\McpServer\Action\Tools\Filesystem\FileWriteAction;
@@ -203,6 +205,8 @@ final class ActionsBootloader extends Bootloader
                 ...$actions,
                 FileReadAction::class,
                 FileReplaceContentAction::class,
+                FileInsertContentAction::class,
+                FileDeleteContentAction::class,
                 FileWriteAction::class,
                 FileSearchAction::class,
                 DirectoryListAction::class,

--- a/tests/src/McpInspector/Tools/FileDeleteContentToolTest.php
+++ b/tests/src/McpInspector/Tools/FileDeleteContentToolTest.php
@@ -1,0 +1,385 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\McpInspector\Tools;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\McpInspector\McpInspectorTestCase;
+
+#[Group('mcp-inspector')]
+final class FileDeleteContentToolTest extends McpInspectorTestCase
+{
+    #[Test]
+    public function it_deletes_single_line(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [['line' => 2]],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(2, $lines);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Line 3', $lines[1]);
+    }
+
+    #[Test]
+    public function it_deletes_multiple_individual_lines(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act - Delete lines 2 and 4
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [['line' => 2], ['line' => 4]],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(3, $lines);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Line 3', $lines[1]);
+        $this->assertEquals('Line 5', $lines[2]);
+    }
+
+    #[Test]
+    public function it_deletes_range_of_lines(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act - Delete lines 2-4
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [
+                ['line' => 2, 'to' => 4],
+            ],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(2, $lines);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Line 5', $lines[1]);
+    }
+
+    #[Test]
+    public function it_deletes_mixed_individual_and_range(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+Line 6
+Line 7
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act - Delete line 2 and lines 4-6
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [
+                ['line' => 2],
+                ['line' => 4, 'to' => 6],
+            ],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(3, $lines);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Line 3', $lines[1]);
+        $this->assertEquals('Line 7', $lines[2]);
+    }
+
+    #[Test]
+    public function it_deletes_first_line(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [['line' => 1]],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(2, $lines);
+        $this->assertEquals('Line 2', $lines[0]);
+        $this->assertEquals('Line 3', $lines[1]);
+    }
+
+    #[Test]
+    public function it_deletes_last_line(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [['line' => 3]],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(2, $lines);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Line 2', $lines[1]);
+    }
+
+    #[Test]
+    public function it_deletes_php_code_lines(): void
+    {
+        // Arrange
+        $phpContent = <<<'PHP'
+<?php
+
+namespace App;
+
+use App\OldImport;
+use App\AnotherOldImport;
+
+class Service
+{
+}
+PHP;
+        $this->createFile('Service.php', $phpContent);
+
+        // Act - Delete the old import lines (5 and 6)
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'Service.php',
+            'lines' => [['line' => 5], ['line' => 6]],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/Service.php');
+        $this->assertStringNotContainsString('OldImport', $newContent);
+        $this->assertStringNotContainsString('AnotherOldImport', $newContent);
+        $this->assertStringContainsString('class Service', $newContent);
+    }
+
+    #[Test]
+    public function it_handles_reversed_range(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act - Use reversed range (line > to), should still work
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [
+                ['line' => 4, 'to' => 2],
+            ],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(2, $lines);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Line 5', $lines[1]);
+    }
+
+    #[Test]
+    public function it_handles_duplicate_line_numbers(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act - Specify line 2 multiple times
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [['line' => 2], ['line' => 2], ['line' => 2]],
+        ]);
+
+        // Assert - Should only delete once
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(2, $lines);
+    }
+
+    #[Test]
+    public function it_fails_for_non_existent_file(): void
+    {
+        // Act
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'non-existent.txt',
+            'lines' => [['line' => 1]],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_fails_for_invalid_line_number(): void
+    {
+        // Arrange
+        $this->createFile('test.txt', "Line 1\nLine 2");
+
+        // Act - Try to delete line 10 which doesn't exist
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [['line' => 10]],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_fails_for_zero_line_number(): void
+    {
+        // Arrange
+        $this->createFile('test.txt', "Line 1\nLine 2");
+
+        // Act - Line numbers are 1-based, 0 is invalid
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [['line' => 0]],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_fails_for_missing_path(): void
+    {
+        // Act
+        $result = $this->inspector->callTool('file-delete-content', [
+            'lines' => [['line' => 1]],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_fails_for_empty_lines(): void
+    {
+        // Arrange
+        $this->createFile('test.txt', 'content');
+
+        // Act
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_blocks_path_traversal_attempts(): void
+    {
+        // Act
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => '../../../etc/passwd',
+            'lines' => [['line' => 1]],
+        ]);
+
+        // Assert - should fail or return error
+        $this->assertTrue(
+            !$result->success || $result->isToolError(),
+            'Path traversal should be blocked',
+        );
+    }
+
+    #[Test]
+    public function it_deletes_all_lines_except_one(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Keep this line
+Delete 1
+Delete 2
+Delete 3
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act - Delete lines 2-4
+        $result = $this->inspector->callTool('file-delete-content', [
+            'path' => 'test.txt',
+            'lines' => [
+                ['line' => 2, 'to' => 4],
+            ],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $this->assertEquals('Keep this line', $newContent);
+    }
+}

--- a/tests/src/McpInspector/Tools/FileInsertContentToolTest.php
+++ b/tests/src/McpInspector/Tools/FileInsertContentToolTest.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\McpInspector\Tools;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\McpInspector\McpInspectorTestCase;
+
+#[Group('mcp-inspector')]
+final class FileInsertContentToolTest extends McpInspectorTestCase
+{
+    #[Test]
+    public function it_inserts_content_after_line(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => 2, 'content' => 'Inserted Line'],
+            ],
+            'position' => 'after',
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(4, $lines);
+        $this->assertEquals('Line 2', $lines[1]);
+        $this->assertEquals('Inserted Line', $lines[2]);
+        $this->assertEquals('Line 3', $lines[3]);
+    }
+
+    #[Test]
+    public function it_inserts_content_before_line(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => 2, 'content' => 'Inserted Line'],
+            ],
+            'position' => 'before',
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(4, $lines);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Inserted Line', $lines[1]);
+        $this->assertEquals('Line 2', $lines[2]);
+    }
+
+    #[Test]
+    public function it_inserts_at_end_of_file_with_minus_one(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => -1, 'content' => 'Last Line'],
+            ],
+            'position' => 'after',
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(3, $lines);
+        $this->assertEquals('Last Line', $lines[2]);
+    }
+
+    #[Test]
+    public function it_inserts_multiple_lines_with_offset_calculation(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act - Insert at lines 2 and 4 (original numbering)
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => 2, 'content' => 'After Line 2'],
+                ['line' => 4, 'content' => 'After Line 4'],
+            ],
+            'position' => 'after',
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(7, $lines);
+        // Line 1, Line 2, After Line 2, Line 3, Line 4, After Line 4, Line 5
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Line 2', $lines[1]);
+        $this->assertEquals('After Line 2', $lines[2]);
+        $this->assertEquals('Line 3', $lines[3]);
+        $this->assertEquals('Line 4', $lines[4]);
+        $this->assertEquals('After Line 4', $lines[5]);
+        $this->assertEquals('Line 5', $lines[6]);
+    }
+
+    #[Test]
+    public function it_inserts_multiline_content(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => 1, 'content' => "Multi\nLine\nContent"],
+            ],
+            'position' => 'after',
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertCount(5, $lines);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Multi', $lines[1]);
+        $this->assertEquals('Line', $lines[2]);
+        $this->assertEquals('Content', $lines[3]);
+        $this->assertEquals('Line 2', $lines[4]);
+    }
+
+    #[Test]
+    public function it_inserts_php_code(): void
+    {
+        // Arrange
+        $phpContent = <<<'PHP'
+<?php
+
+namespace App;
+
+class Service
+{
+}
+PHP;
+        $this->createFile('Service.php', $phpContent);
+
+        // Act - Insert use statement after namespace line
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'Service.php',
+            'insertions' => [
+                ['line' => 4, 'content' => 'use App\Repository\UserRepository;'],
+            ],
+            'position' => 'after',
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/Service.php');
+        $this->assertStringContainsString('use App\Repository\UserRepository;', $newContent);
+    }
+
+    #[Test]
+    public function it_fails_for_non_existent_file(): void
+    {
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'non-existent.txt',
+            'insertions' => [
+                ['line' => 1, 'content' => 'test'],
+            ],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_fails_for_invalid_line_number(): void
+    {
+        // Arrange
+        $this->createFile('test.txt', "Line 1\nLine 2");
+
+        // Act - Try to insert at line 10 which doesn't exist
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => 10, 'content' => 'test'],
+            ],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_fails_for_missing_path(): void
+    {
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'insertions' => [
+                ['line' => 1, 'content' => 'test'],
+            ],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_fails_for_empty_insertions(): void
+    {
+        // Arrange
+        $this->createFile('test.txt', 'content');
+
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [],
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_fails_for_invalid_position(): void
+    {
+        // Arrange
+        $this->createFile('test.txt', 'content');
+
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => 1, 'content' => 'test'],
+            ],
+            'position' => 'invalid',
+        ]);
+
+        // Assert
+        $this->assertToolError($result);
+    }
+
+    #[Test]
+    public function it_blocks_path_traversal_attempts(): void
+    {
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => '../../../etc/passwd',
+            'insertions' => [
+                ['line' => 1, 'content' => 'hacked'],
+            ],
+        ]);
+
+        // Assert - should fail or return error
+        $this->assertTrue(
+            !$result->success || $result->isToolError(),
+            'Path traversal should be blocked',
+        );
+    }
+
+    #[Test]
+    public function it_uses_after_as_default_position(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act - No position specified, should default to 'after'
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => 1, 'content' => 'Inserted'],
+            ],
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertEquals('Line 1', $lines[0]);
+        $this->assertEquals('Inserted', $lines[1]);
+        $this->assertEquals('Line 2', $lines[2]);
+    }
+
+    #[Test]
+    public function it_inserts_at_first_line_before(): void
+    {
+        // Arrange
+        $content = <<<'TEXT'
+Line 1
+Line 2
+TEXT;
+        $this->createFile('test.txt', $content);
+
+        // Act
+        $result = $this->inspector->callTool('file-insert-content', [
+            'path' => 'test.txt',
+            'insertions' => [
+                ['line' => 1, 'content' => 'Very First Line'],
+            ],
+            'position' => 'before',
+        ]);
+
+        // Assert
+        $this->assertInspectorSuccess($result);
+        $newContent = \file_get_contents($this->workDir . '/test.txt');
+        $lines = \explode("\n", $newContent);
+        $this->assertEquals('Very First Line', $lines[0]);
+        $this->assertEquals('Line 1', $lines[1]);
+    }
+}


### PR DESCRIPTION
Add two new MCP file manipulation tools to complement the existing FileReplaceContent tool:
  - FileInsertContent: Insert content at specific line number(s) with automatic line offset calculation for batch operations
  - FileDeleteContent: Delete content at specific line number(s) with support     for single lines and ranges

Key features:
  - Line-based operations when pattern matching is not ideal
  - Support for batch insertions/deletions with automatic offset tracking
  - Insert position control (before/after specified line)
  - Range deletion support (e.g., {"line": 5, "to": 10})
  - End-of-file insertion using line=-1

  DTOs use typed arrays with #[Field] attributes for proper JSON schema generation:
  - InsertionItem: line (int) + content (string)
  - DeletionItem: line (int) + optional to (int) for ranges

  Closes #310